### PR TITLE
{Reviewer: Matt} Remove the hss_enabled configuration setting, as Homestead now simply ch...

### DIFF
--- a/cookbooks/clearwater/templates/default/config.erb
+++ b/cookbooks/clearwater/templates/default/config.erb
@@ -24,9 +24,10 @@ smtp_password=<%= @node[:clearwater][:smtp_password] %>
 email_recovery_sender=<%= @node[:clearwater][:email_sender] %>
 
 # HSS configuration
-hss_enabled=<%= @node[:clearwater][:hss_enabled] %>
 hss_hostname=<%= @node[:clearwater][:hss_hostname] %>
 hss_port=<%= @node[:clearwater][:hss_port] %>
+
+# Database configuration
 cassandra_hostname=<%= @node[:clearwater][:cassandra_hostname] %>
 
 # Keys

--- a/environments/template.rb
+++ b/environments/template.rb
@@ -10,7 +10,6 @@ override_attributes "clearwater" => {
   "keypair" => "<keypair_name>",
   "keypair_dir" => "/home/ubuntu/.chef/",
   "pstn_number_count" => 0,
-  "hss_enabled" => "False",
   "hss_hostname" => "0.0.0.0",
   "hss_port" => 3868,
   "cassandra_hostname" => "localhost",

--- a/roles/clearwater-infrastructure.rb
+++ b/roles/clearwater-infrastructure.rb
@@ -100,16 +100,13 @@ default_attributes "clearwater" => {
   # to a secure value.
   "ellis_cookie_key" => Chef::Config[:knife][:ellis_cookie_key],
 
-  # Secret keys for Homer and Homestead. Set to a secure value.
+  # Secret keys for Homestead-stored passwords. Set to a secure value.
   "homestead_password_encryption_key" => Chef::Config[:knife][:homestead_password_encryption_key],
 
   # Cassandra hostname for both homer and homestead.
   "cassandra_hostname" => "localhost",
 
-  # Set to "True" to enable integration with an external HSS.
-  "hss_enabled" => "False",
-
-  # HSS configuration details. Only used when hss_enabled is "True".
+  # HSS configuration settings.
   "hss_hostname" => "0.0.0.0",
   "hss_port" => 3868,
 


### PR DESCRIPTION
...ecks whether the IP address is blank/all zeroes.

Chef changes to match https://github.com/Metaswitch/crest/pull/22.
