### PR TITLE
Reviewer Matt:Relax monit requirement on Cassandra - Issue #28

### DIFF
--- a/cookbooks/clearwater/templates/default/cassandra/cassandra.monit
+++ b/cookbooks/clearwater/templates/default/cassandra/cassandra.monit
@@ -7,4 +7,5 @@ check process cassandra pidfile /var/run/cassandra.pid
   stop program = "/etc/init.d/cassandra stop"
   if failed host localhost port 9160 type TCP 
     with timeout 15 seconds
+    for 3 times within 3 cycles
     then restart


### PR DESCRIPTION
Tested by simulating a non-responsive cassandra by:
- Repeatedly restarting it (outside of monit)
- Hacking in the wrong port number in cassandra.monit

and verifying that monit doesn't restart Cassandra unless it fails three times in a row
