### PR TITLE
Reviewer Matt: Make mmonit configuration conditional

### DIFF
--- a/cookbooks/clearwater/templates/default/config.erb
+++ b/cookbooks/clearwater/templates/default/config.erb
@@ -5,9 +5,11 @@ hs_hostname=hs.<%= @domain %>:8888
 garden_hostname=localhost
 xdms_hostname=homer.<%= @domain %>:7888
 splunk_hostname=<%= @node[:clearwater][:splunk_server] || "0.0.0.0" %>
+<% if [:mmonit_server, :mmonit_username, :mmonit_password].all? { |k| @node[:clearwater].has_key? k } %>
 mmonit_hostname=<%= @node[:clearwater][:mmonit_server] %>
 mmonit_username=<%= @node[:clearwater][:mmonit_username] %>
 mmonit_password=<%= @node[:clearwater][:mmonit_password] %>
+<% end %>
 sas_server=<%= @sas %>
 enum_server=<%= @enum %>
 <% if not @node[:clearwater][:index].nil? %>node_idx=<%= @node[:clearwater][:index] %><% end %>

--- a/roles/clearwater-infrastructure.rb
+++ b/roles/clearwater-infrastructure.rb
@@ -121,11 +121,6 @@ default_attributes "clearwater" => {
   # must be validated or email sending will fail.
   "email_sender"    => Chef::Config[:knife][:email_sender],
 
-  # MMonit server credentials, if any.
-  "mmonit_server"   => Chef::Config[:knife][:mmonit_server],
-  "mmonit_username" => Chef::Config[:knife][:mmonit_username],
-  "mmonit_password" => Chef::Config[:knife][:mmonit_password],
-
   # DNS server configuration - internal subnet to forward requests from and
   # DNS forwarder to use when doing so.
   "dns_internal_subnet" => "10.0.0.0/8",


### PR DESCRIPTION
Supporting Chef changes for M/Monit fix in clearwater-infrastructure. The view is that going forward, mmonit is optional and by default is not configured. It is expected that these parameters will be configured in the environment file
