### PR TITLE
[No review needed] Can't use index as a function

### DIFF
--- a/cookbooks/clearwater/recipes/cluster.rb
+++ b/cookbooks/clearwater/recipes/cluster.rb
@@ -218,7 +218,7 @@ if node.roles.include? "cassandra"
 
       # To prevent conflicts during clustering, only homestead-1 or homer-1
       # will ever attempt to create Keyspaces.
-      only_if { node.clearwater.index == 1 }
+      only_if { node[:clearwater][:index] == 1 }
       action :run
     end
 


### PR DESCRIPTION
`index` is a function on `Hash` so the Chef-magic won't work on it.
