### PR TITLE
[Reviewer: Andy] Remove cw_aio flag as no longer required

### DIFF
--- a/cookbooks/clearwater/templates/default/config.erb
+++ b/cookbooks/clearwater/templates/default/config.erb
@@ -13,7 +13,6 @@ mmonit_password=<%= @node[:clearwater][:mmonit_password] %>
 sas_server=<%= @sas %>
 enum_server=<%= @enum %>
 <% if not @node[:clearwater][:index].nil? %>node_idx=<%= @node[:clearwater][:index] %><% end %>
-<% if @node.roles.include? "cw_aio" %>cw_aio=True<% end %>
 
 # Local IP configuration
 local_ip=<%= @node[:cloud][:local_ipv4] %>


### PR DESCRIPTION
Andy, this is the chef change corresponding to my clearwater-infrastructure change to remove the cw_aio flag.  Please can you review but not merge (as I'll merge to master once Tim's merged his changes)?
