### PR TITLE
[Reviewer: Andy] Remove references to garden - no-one uses it any more

### DIFF
--- a/cookbooks/clearwater/templates/default/config.erb
+++ b/cookbooks/clearwater/templates/default/config.erb
@@ -2,7 +2,6 @@
 home_domain=<%= @domain %>
 sprout_hostname=<%= @sprout %>
 hs_hostname=<%= @hs %>
-garden_hostname=localhost
 xdms_hostname=<%= @homer %>
 splunk_hostname=<%= @node[:clearwater][:splunk_server] || "0.0.0.0" %>
 <% if [:mmonit_server, :mmonit_username, :mmonit_password].all? { |k| @node[:clearwater].has_key? k } %>


### PR DESCRIPTION
Andy, garden_hostname is not used any more.  Let's remove it.  I've already checked that we don't talk about setting it in the manual install instructions.
