### PR TITLE
[Reviewer: Andy] Add reg_max_expires to the clearwater config template

### DIFF
--- a/cookbooks/clearwater/templates/default/config.erb
+++ b/cookbooks/clearwater/templates/default/config.erb
@@ -31,6 +31,9 @@ hss_port=<%= @node[:clearwater][:hss_port] %>
 # Database configuration
 cassandra_hostname=<%= @node[:clearwater][:cassandra_hostname] %>
 
+# Registrar configuration
+<% if @node[:clearwater][:reg_max_expires] %>reg_max_expires=<%= @node[:clearwater][:reg_max_expires] %><% end %>
+
 # Keys
 signup_key="<%= @node[:clearwater][:signup_key] %>"
 turn_workaround="<%= @node[:clearwater][:turn_workaround] %>"


### PR DESCRIPTION
Change to the /etc/clearwater/config  template to add the reg_max_expires parameter. Docs to follow. 

Tested by updating my environment overrides and running chef-client on a sprout node. 
