### PR TITLE
Reviewer Mike - Handle the case that the remote partners are not listening yet

### DIFF
--- a/cookbooks/clearwater/recipes/cluster.rb
+++ b/cookbooks/clearwater/recipes/cluster.rb
@@ -64,6 +64,8 @@ if node.run_list.include? "role[sprout]"
   sprouts.each do |s|
     execute "poke[#{s}]" do
       command "nc #{s} 7800 -z"
+      returns [0,1] # If the remote is not listening on the correct port,
+                    # we'll get 1 as the response code.
       not_if { node.attribute? "clustered" }
     end
   end


### PR DESCRIPTION
This resolves the issues with the demo today, but I'm not sure we're doing enough yet to make arbitrary scale up work reliably.

Bela’s description of why this issue occurs suggests that, though our workaround helps, there’s still no guarantees that when spinning up multiple Sprouts at once, they’ll successfully cluster.  Bela suggests switching to MERGE3 or taking the patch he wrote for us, but we probably need to do some testing on this before just chucking it into the codebase.
