### PR TITLE
[Reviewer: Mike] Only specify enum_server if one is configured for this environment

### DIFF
--- a/cookbooks/clearwater/recipes/infrastructure.rb
+++ b/cookbooks/clearwater/recipes/infrastructure.rb
@@ -91,17 +91,8 @@ domain = if node[:clearwater][:use_subdomain]
            node[:clearwater][:root_domain]
          end
 
-begin
-  sas = Resolv::DNS.open { |dns| dns.getaddress(node[:clearwater][:sas_server]).to_s }
-rescue
-  sas = "0.0.0.0"
-end
-
-begin
-  enum = Resolv::DNS.open { |dns| dns.getaddress(node[:clearwater][:enum_server]).to_s }
-rescue
-  enum = "127.0.0.1"
-end
+sas = Resolv::DNS.open { |dns| dns.getaddress(node[:clearwater][:sas_server]).to_s } rescue "0.0.0.0"
+enum = Resolv::DNS.open { |dns| dns.getaddress(node[:clearwater][:enum_server]).to_s } rescue nil
 
 if node.roles.include? "cw_aio"
   template "/etc/clearwater/config" do

--- a/cookbooks/clearwater/templates/default/config.erb
+++ b/cookbooks/clearwater/templates/default/config.erb
@@ -10,7 +10,7 @@ mmonit_username=<%= @node[:clearwater][:mmonit_username] %>
 mmonit_password=<%= @node[:clearwater][:mmonit_password] %>
 <% end %>
 sas_server=<%= @sas %>
-enum_server=<%= @enum %>
+<% if not @enum.nil? %>enum_server=<%= @enum %><% end %>
 <% if not @node[:clearwater][:index].nil? %>node_idx=<%= @node[:clearwater][:index] %><% end %>
 
 # Local IP configuration

--- a/roles/clearwater-infrastructure.rb
+++ b/roles/clearwater-infrastructure.rb
@@ -75,7 +75,7 @@ default_attributes "clearwater" => {
   "splunk_server" => "0.0.0.0",
 
   # ENUM server to use.  To use the default (public) servers, specify "localhost".
-  "enum_server" => "localhost",
+  "enum_server" => nil,
 
   #
   # The following values should be set in knife.rb; we copy them into


### PR DESCRIPTION
Mike, this is the chef change corresponding to the sprout change to default enum.  The key point is that we only fill in the enum_server property in /etc/clearwater/config if the enum server is set.  Please can you review?
