### PR TITLE
Reviewer Mike - Add the bono.<domain> DNS entry

### DIFF
--- a/plugins/knife/clearwater-dns-records.rb
+++ b/plugins/knife/clearwater-dns-records.rb
@@ -48,6 +48,12 @@ def dns_records
       :ttl   => "60"
     },
 
+    "bono" => {
+      :type  => "A",
+      :value => ipv4s_local(find_nodes(role: "bono")),
+      :ttl   => "60"
+    },
+
     "hs" => {
       :type  => "A",
       :value => ipv4s_local(find_nodes(role: "homestead")),


### PR DESCRIPTION
This goes with the previous code review I sent you (in sprout) and creates the bono cluster domain, using the local IP addresses so sprout and Perimeta can generically refer to bonos.
