### PR TITLE
[Reviewer Andy] Various issues in chef deployment resize function related to --finish option

### DIFF
--- a/plugins/knife/knife-box-list.rb
+++ b/plugins/knife/knife-box-list.rb
@@ -57,8 +57,9 @@ module ClearwaterKnifePlugins
         else
           print "Found node #{node.name} with hostname #{node.cloud.public_hostname} ip #{node.cloud.local_ipv4}"
         end
-        print (node.roles.include?("sprout") and not node[:clearwater].include?("merged")) ? " (joining registration store cluster)" : ""
-        puts node[:clearwater].include?("quiescing") ? " (quiescing since #{node[:clearwater]['quiescing']})" : ""
+        print " (joining registration store cluster)" if node.roles.include?("sprout") and not node[:clearwater].include?("merged")
+        print " (quiescing since #{node[:clearwater]['quiescing']})" if node[:clearwater].include?("quiescing")
+        puts ""
 
       end.empty?
     end

--- a/plugins/knife/knife-deployment-resize.rb
+++ b/plugins/knife/knife-deployment-resize.rb
@@ -369,12 +369,12 @@ module ClearwaterKnifePlugins
       # create one.
       new_counts = {
         ellis: 1,
-        bono: config[:bono_count] || old_counts[:bono] != 0 ? old_counts[:bono] : 1,
-        homestead: config[:homestead_count] || old_counts[:homestead] != 0 ? old_counts[:homestead] : 1,
-        homer: config[:homer_count] || old_counts[:homer] != 0 ? old_counts[:homer] : 1,
-        sprout: config[:sprout_count] || old_counts[:sprout] != 0 ? old_counts[:sprout] : 1,
+        bono: config[:bono_count] || [old_counts[:bono], 1].max,
+        homestead: config[:homestead_count] || [old_counts[:homestead], 1].max,
+        homer: config[:homer_count] || [old_counts[:homer], 1].max,
+        sprout: config[:sprout_count] || [old_counts[:sprout], 1].max,
         ibcf: config[:ibcf_count] || old_counts[:ibcf],
-        sipp: config[:sipp_count] || old_counts[:sipp]}
+        sipp: config[:sipp_count] || old_counts[:sipp] }
 
       if not in_stable_state? env
         if old_counts == new_counts


### PR DESCRIPTION
Andy

Can you review.  See the issue for the detailed list of what this is fixing.  Also, it changes the behaviour of knife deployment resize as we discussed earlier today - if a particular --*-count option is specified you get what you got - unless the node type is one of homer, homestead, bono, sprout and you have none, in which case you get one.

Tested live by running through various scale-up/scale-down scenarios.

Mike
