### PR TITLE
[Reviewer Andy] Reverse sense of merged attributed to a joining attribute to make upgrades of existing systems work

### DIFF
--- a/cookbooks/clearwater/recipes/cluster.rb
+++ b/cookbooks/clearwater/recipes/cluster.rb
@@ -52,19 +52,19 @@ if node.run_list.include? "role[sprout]"
                    "role:sprout AND chef_environment:#{node.chef_environment}")
   sprouts.sort_by! { |n| n[:clearwater][:index] }
 
-  # Strip this down to the list of already merged sprouts and the list of
-  # non-quiescing sprouts
-  merged = sprouts.find_all { |s| s[:clearwater][:merged] }
+  # Strip this down to the list of sprouts that have already joined the cluster
+  # and the list that are not quiescing sprouts
+  joined = sprouts.find_all { |s| not s[:clearwater][:joining] }
   nonquiescing = sprouts.find_all { |s| not s[:clearwater][:quiescing] }
 
-  if merged.size == sprouts.size and nonquiescing.size == sprouts.size
+  if joined.size == sprouts.size and nonquiescing.size == sprouts.size
     # Cluster is stable, so just include the server list.
     servers = sprouts
     new_servers = []
   else
-    # Cluster is growing or shrinking, so use the merged list as the servers
+    # Cluster is growing or shrinking, so use the joined list as the servers
     # list and the nonquiescing list as the new servers list.
-    servers = merged
+    servers = joined
     new_servers = nonquiescing
   end
 

--- a/plugins/knife/knife-box-list.rb
+++ b/plugins/knife/knife-box-list.rb
@@ -57,7 +57,7 @@ module ClearwaterKnifePlugins
         else
           print "Found node #{node.name} with hostname #{node.cloud.public_hostname} ip #{node.cloud.local_ipv4}"
         end
-        print " (joining registration store cluster)" if node.roles.include?("sprout") and not node[:clearwater].include?("merged")
+        print " (joining registration store cluster)" if node.roles.include?("sprout") and node[:clearwater].include?("joining")
         print " (quiescing since #{node[:clearwater]['quiescing']})" if node[:clearwater].include?("quiescing")
         puts ""
 


### PR DESCRIPTION
Andy

Can you review please.  I've tested by
-  spinning up a new deployment from scratch and checking that the cluster_settings files is set up as expected despite there being no attributes set
-  growing the sprout cluster to check that the new node has the joining attribute set and the cluster_settings are right
-  finishing the scale up to check that the attributes are cleared and the cluster_settings change to the stable setting.

I ran live tests at each stage to check sprout was doing the right thing.

Mike
