### PR TITLE
{Reviewer: Matt} Restore option to auto-upgrade packages

### DIFF
--- a/cookbooks/clearwater/recipes/infrastructure.rb
+++ b/cookbooks/clearwater/recipes/infrastructure.rb
@@ -130,13 +130,13 @@ package "clearwater-infrastructure" do
 end
 
 if node[:clearwater][:package_update_minutes]
-  package "clearwater-auto-update" do
+  package "clearwater-auto-upgrade" do
     action [:install]
     options "--force-yes"
   end
 
   cron "package update" do
     minute ("*/" + node[:clearwater][:package_update_minutes].to_s)
-    command "service clearwater-auto-update restart"
+    command "service clearwater-auto-upgrade restart"
   end
 end


### PR DESCRIPTION
Matt,

This restores the old behaviour of the package_update_minutes option (i.e. updating the deployment's packages every few minutes).
