### PR TITLE
`undefined local variable or method `expected'` finishing a re-size operation

### DIFF
--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -269,16 +269,17 @@ def box_ready_to_delete?(box_name, env)
   @ssh_key = File.join(attributes["keypair_dir"], "#{attributes["keypair"]}.pem")
   ssh_options = { keys: @ssh_key }
   ssh_return = ""
+  expected = ""
 
   Net::SSH.start(hostname, "ubuntu", ssh_options) do |ssh|
     case node.run_list.first.name
     when "sprout"
-      ssh_return = ssh.exec! "sudo pgrep -lf sprout > /dev/null; echo $?"
+      ssh_return = ssh.exec! "pgrep sprout > /dev/null; echo $?"
       expected = "1\n"
       # If we have quiesced, pgrep shouldn't find a process and should
       # fail
     when "bono"
-      ssh_return = ssh.exec! "sudo pgrep -lf bono > /dev/null; echo $?"
+      ssh_return = ssh.exec! "pgrep bono > /dev/null; echo $?"
       expected = "1\n"
       # If we have quiesced, pgrep shouldn't find a process and should
       # fail
@@ -293,12 +294,11 @@ def box_ready_to_delete?(box_name, env)
       # If we have quiesced, grep should find the word
       # "decommissioned" and succeed
     else
-      # No quiescing activity for other sorts of boxes - just return true
-      return true
+      # No quiescing activity for other sorts of boxes
     end
   end
 
-  # Check that $? is 0 (i.e. the SSH command executed successfully)
+  # Check that the returned value is as expected.
   return ssh_return.eql?(expected)
 
 end


### PR DESCRIPTION
Representative backtrace:

```
knife deployment resize -E clearwater --finish -VV

INFO: Creating deployment in environment: clearwater
DEBUG: Signing the request as chef-client
DEBUG: Sending HTTP Request via GET to chef-server.my-domain.me:4000/environments/clearwater
DEBUG: ---- HTTP Status and Header Data: ----
DEBUG: HTTP 1.1 200 OK
DEBUG: content-type: application/json; charset=utf-8
DEBUG: connection: close
DEBUG: server: thin 1.3.1 codename Triple Espresso
DEBUG: ---- End HTTP Status/Header Data ----
DEBUG: Signing the request as chef-client
DEBUG: Sending HTTP Request via GET to chef-server.my-domain.me:4000/search/node
DEBUG: ---- HTTP Status and Header Data: ----
DEBUG: HTTP 1.1 200 OK
DEBUG: content-type: application/json; charset=utf-8
DEBUG: connection: close
DEBUG: server: thin 1.3.1 codename Triple Espresso
DEBUG: ---- End HTTP Status/Header Data ----
DEBUG: Signing the request as chef-client
DEBUG: Sending HTTP Request via GET to chef-server.my-domain.me:4000/nodes/clearwater-sprout-4
DEBUG: ---- HTTP Status and Header Data: ----
DEBUG: HTTP 1.1 200 OK
DEBUG: content-type: application/json; charset=utf-8
DEBUG: connection: close
DEBUG: server: thin 1.3.1 codename Triple Espresso
DEBUG: ---- End HTTP Status/Header Data ----
DEBUG: Signing the request as chef-client
DEBUG: Sending HTTP Request via GET to chef-server.my-domain.me:4000/roles/clearwater-infrastructure
DEBUG: ---- HTTP Status and Header Data: ----
DEBUG: HTTP 1.1 200 OK
DEBUG: content-type: application/json; charset=utf-8
DEBUG: connection: close
DEBUG: server: thin 1.3.1 codename Triple Espresso
DEBUG: ---- End HTTP Status/Header Data ----
/home/ubuntu/chef/.chef/plugins/knife/boxes.rb:302:in `box_ready_to_delete?': undefined local variable or method `expected' for #<ClearwaterKnifePlugins::DeploymentResize:0x00000002790bb0> (NameError)
    from /home/ubuntu/chef/.chef/plugins/knife/boxes.rb:348:in `block in find_incomplete_quiescing_nodes'
    from /home/ubuntu/chef/.chef/plugins/knife/boxes.rb:347:in `select'
    from /home/ubuntu/chef/.chef/plugins/knife/boxes.rb:347:in `find_incomplete_quiescing_nodes'
    from /home/ubuntu/chef/.chef/plugins/knife/knife-deployment-resize.rb:324:in `run'
    from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/gems/chef-11.4.0/lib/chef/knife.rb:460:in `run_with_pretty_exceptions'
    from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/gems/chef-11.4.0/lib/chef/knife.rb:173:in `run'
    from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/gems/chef-11.4.0/lib/chef/application/knife.rb:123:in `run'
    from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/gems/chef-11.4.0/bin/knife:25:in `<top (required)>'
    from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/bin/knife:19:in `load'
    from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/bin/knife:19:in `<main>'
    from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/bin/ruby_executable_hooks:15:in `eval'
    from /home/ubuntu/.rvm/gems/ruby-1.9.3-p448/bin/ruby_executable_hooks:15:in `<main>'
```

This looks to be caused by `expected` being defined inside the `Net::SSH.start` block but being referenced outside (unlike the `ssh_return` parameter).
