### PR TITLE
[Reviewer Andy] Pause for 5 seconds between each schema change, and retry after SchemaDisagreementException

### DIFF
--- a/cookbooks/clearwater/recipes/cluster.rb
+++ b/cookbooks/clearwater/recipes/cluster.rb
@@ -268,7 +268,6 @@ if node.roles.include? "cassandra"
               # Pass
             end
           end
-
         end
 
         # To prevent conflicts during clustering, only homestead-1 or homer-1


### PR DESCRIPTION
Andy

Can you review.  This is my fix to the problem defining the schema when spinning up multiple Homestead nodes at start of day.  I'm not sure it 100% fixes the problem, but it certainly makes it much less likely.

Mike
