### PR TITLE
Reviewer Rob - Include minute specifier in cron resource

### DIFF
--- a/cookbooks/clearwater/recipes/ellis.rb
+++ b/cookbooks/clearwater/recipes/ellis.rb
@@ -39,6 +39,7 @@ end
 
 # Perform daily backup of database
 cron "backup" do
+  minute 0
   hour 0 
   command "/usr/share/clearwater/ellis/backup/do_backup.sh"
 end


### PR DESCRIPTION
This fixes https://github.com/Metaswitch/ellis/issues/46 by specifying the minute as well as the hour when creating the crontab for Ellis's backups.

I've tested this by spinning up an Ellis node and checking the generated crontab by eye.
