### PR TITLE
[Reviewer: Matt, From: Alex] Open up ports 6667 on homestead and homer

### DIFF
--- a/cookbooks/clearwater/metadata.rb
+++ b/cookbooks/clearwater/metadata.rb
@@ -37,4 +37,4 @@ maintainer_email "YOUR_EMAIL"
 license          "All rights reserved"
 description      "Installs/Configures clearwater"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.1982"
+version          "0.1.0"


### PR DESCRIPTION
Matt, please could you review this change to open up ports 6666 _and_ 6667 on homestead, and 6667 _only_ on homer. This is a co-req change to moving crest to publish to port 6667.

Once this is pushed I will update [Clearwater IP port usage](https://github.com/Metaswitch/clearwater-docs/wiki/Clearwater%20IP%20Port%20Usage)

Tested by spinning up a new deployment and checking security group settings manually. 
