### PR TITLE
[Reviewer: Andy] Default to disabling SAS - setting to localhost does not disable it

### DIFF
--- a/roles/clearwater-infrastructure.rb
+++ b/roles/clearwater-infrastructure.rb
@@ -69,7 +69,7 @@ default_attributes "clearwater" => {
   # allows so we'll use that until we test on other clouds.
   "dns_ttl" => 300,
 
-  # Sas server to use. To disable SAS, set to an invalid host, e.g "0.0.0.0"
+  # Sas server to use. To disable SAS, set to "0.0.0.0".
   "sas_server" => "0.0.0.0",
 
   # Splunk server to use. To disable splunk, set an invalid host, e.g. "0.0.0.0"


### PR DESCRIPTION
Andy,

Please can you review this fix to default to disabling SAS by setting it to `0.0.0.0` - setting it to `localhost` does not disable it - connections are still attempted.

Matt
