### PR TITLE
Reviewer Alex - Open port 11211 to other Ralfs, not to Sprouts

### DIFF
--- a/plugins/knife/clearwater-security-groups.rb
+++ b/plugins/knife/clearwater-security-groups.rb
@@ -175,7 +175,7 @@ def ralf_security_group_rules
      { ip_protocol: :tcp, min: 10888, max: 10888, group: "ralf" },
      { ip_protocol: :tcp, min: 7253, max: 7253, group: "ralf" },
      # Memcached interface
-     { ip_protocol: :tcp, min: 11211, max: 11211, group: "sprout" },
+     { ip_protocol: :tcp, min: 11211, max: 11211, group: "ralf" },
      # Statistics interface
      { ip_protocol: :tcp, min: 6664, max: 6664, cidr_ip: "0.0.0.0/0" },
     ]


### PR DESCRIPTION
This fixes #121 using the fix you suggested.  I've tested on my deployment and the correct rule was added, I've gone through the rest of the security group rules for Ralf and they look correct.
