### PR TITLE
[Reviewer: Alex] Don't use localhost and don't set Ralf for all-in-one nodes

### DIFF
--- a/cookbooks/clearwater/recipes/infrastructure.rb
+++ b/cookbooks/clearwater/recipes/infrastructure.rb
@@ -90,7 +90,7 @@ unless Chef::Config[:solo]
                 hs_prov: node[:cloud][:local_ipv4] + ":8889",
                 homer: node[:cloud][:local_ipv4] + ":7888",
                 chronos: node[:cloud][:local_ipv4] + ":7253",
-                ralf: nil,
+                ralf: "",
                 enum: enum
     end
     package "clearwater-auto-config-aws" do

--- a/cookbooks/clearwater/templates/default/config.erb
+++ b/cookbooks/clearwater/templates/default/config.erb
@@ -5,7 +5,7 @@ hs_hostname=<%= @hs %>
 chronos_hostname=<%= @chronos %>
 hs_provisioning_hostname=<%= @hs_prov %>
 xdms_hostname=<%= @homer %>
-<% if not @ralf.nil? %>ralf_hostname=<%= @ralf %><% end %>
+ralf_hostname=<%= @ralf %>
 sas_server=<%= @node[:clearwater][:sas_server] or "0.0.0.0" %>
 <% if not @enum.nil? %>enum_server=<%= @enum %><% end %>
 <% if not @node[:clearwater][:index].nil? %>node_idx=<%= @node[:clearwater][:index] %><% end %>


### PR DESCRIPTION
Alex, can you review this change to use the local ip instead of localhost for the all-in-one nodes. I've also changed it so the ralf_hostname is no longer set for all-in-one nodes
