### PR TITLE
[Reviewer: Rob] Correct the URL we download Openimscorehss from

### DIFF
--- a/cookbooks/clearwater/recipes/openimscorehss.rb
+++ b/cookbooks/clearwater/recipes/openimscorehss.rb
@@ -43,7 +43,7 @@ directory "/opt/OpenIMSCore" do
 end
 
 subversion "OpenIMSCore HSS" do
-  repository "http://svn.berlios.de/svnroot/repos/openimscore/FHoSS/trunk"
+  repository "http://svn.code.sf.net/p/openimscore/code/FHoSS/trunk"
   destination "/opt/OpenIMSCore/FHoSS"
   action :sync
 end


### PR DESCRIPTION
Rob, please can you review this change to download openimscorehss from the new sourceforge URL. 

I have tested this by running `knife box create -E ajh -V openimscorehss` and successfully using the resulting box.
