### PR TITLE
[Reviewer: Andy] For a HTTPS Clearwater repo, retrieve the keys from a databag

### DIFF
--- a/cookbooks/clearwater/templates/default/apt.keys.erb
+++ b/cookbooks/clearwater/templates/default/apt.keys.erb
@@ -1,9 +1,5 @@
 Acquire::https::<%= @repo_host %> {
-
 CaInfo "/etc/apt/certs/clearwater/repository-ca.crt";
-
 SslCert "/etc/apt/certs/clearwater/repository-server.crt";
-
 SslKey "/etc/apt/certs/clearwater/repository-server.key";
-
 };


### PR DESCRIPTION
Andy,

With this change, if the Clearwater repo server is configured as a HTTPS URL, Chef will retrieve keys from an encrypted databag and set APT up to do client-side authentication.

The prerequisites are:
- You need an encrypted databag called repo_keys/generic, with attributes called "repository-ca.crt", "repository-server.crt" and "repository-server.key", each of which is the relevant PEM-encoded certificate or key. (We could enhance this in future, if we need per-environment keys rather than per-Chef-server keys.)
- You need an `encrypted_data_bag_secret` setting in ~/.chef/knife.rb, pointing at the same file used to encrypt the databag.

I'll send an email to the team with our specific secrets once this is merged.

Tested by spinning up a Clearwater node, both with an HTTPS and a non-HTTPS repo server.
