### PR TITLE
[Reviewer: Matt] Don't create a user_settings file for bono nodes

### DIFF
--- a/cookbooks/clearwater/recipes/bono.rb
+++ b/cookbooks/clearwater/recipes/bono.rb
@@ -32,12 +32,6 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-template "/etc/clearwater/user_settings" do
-  mode "0644"
-  source "bono/user_settings.erb"
-  variables trusted_peers: node[:clearwater][:trusted_peers]
-end
-
 package "bono" do
   action [:install]
   options "--force-yes"

--- a/cookbooks/clearwater/templates/default/bono/user_settings.erb
+++ b/cookbooks/clearwater/templates/default/bono/user_settings.erb
@@ -1,1 +1,0 @@
-trusted_peers="<%= @trusted_peers.join "," %>"

--- a/cookbooks/clearwater/templates/default/config.erb
+++ b/cookbooks/clearwater/templates/default/config.erb
@@ -41,6 +41,8 @@ cassandra_hostname=<%= @node[:clearwater][:cassandra_hostname] %>
 <% else %>upstream_port=5052
 <% end %>
 
+trusted_peers="<%= node[:clearwater][:trusted_peers].join "," %>"
+
 # Keys
 signup_key="<%= @node[:clearwater][:signup_key] %>"
 turn_workaround="<%= @node[:clearwater][:turn_workaround] %>"


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/chef/issues/127. Tested by setting trusted_peers, spinning up a bono node, and checking I had the right --ibcf parameter when it started.
