### PR TITLE
[Reviewer:AMC] Add a CDF line to config template

### DIFF
--- a/cookbooks/clearwater/recipes/infrastructure.rb
+++ b/cookbooks/clearwater/recipes/infrastructure.rb
@@ -126,7 +126,7 @@ unless Chef::Config[:solo]
                 homer: node[:cloud][:local_ipv4] + ":7888",
                 chronos: node[:cloud][:local_ipv4] + ":7253",
                 ralf: "",
-                cdf: "cdf." + domain,
+                cdf: "",
                 enum: enum
     end
     package "clearwater-auto-config-aws" do

--- a/cookbooks/clearwater/templates/default/config.erb
+++ b/cookbooks/clearwater/templates/default/config.erb
@@ -6,7 +6,7 @@ chronos_hostname=<%= @chronos %>
 hs_provisioning_hostname=<%= @hs_prov %>
 xdms_hostname=<%= @homer %>
 ralf_hostname=<%= @ralf %>
-cdf_hostname=<%= @cdf %>
+cdf_identity=<%= @cdf %>
 sas_server=<%= @node[:clearwater][:sas_server] or "0.0.0.0" %>
 <% if not @enum.nil? %>enum_server=<%= @enum %><% end %>
 <% if not @node[:clearwater][:index].nil? %>node_idx=<%= @node[:clearwater][:index] %><% end %>


### PR DESCRIPTION
Just set the CDF to cdf.domain at the moment since we don't have a real cdf

Used as part of sto851 by homestead-prov to specify a ccf when provisioning subscribers

Live tested by spinning up a blank node and checking /etc/clearwater/config
