### PR TITLE
Reviewer AJH: Add memento HTTP DNS record

### DIFF
--- a/plugins/knife/clearwater-dns-records.rb
+++ b/plugins/knife/clearwater-dns-records.rb
@@ -85,6 +85,12 @@ def dns_records
       :value => ipv4s_local(find_active_nodes("memento")),
       :ttl   => "60"
     },
+
+    "mementohttp" => {
+      :type  => "A",
+      :value => ipv4s(find_active_nodes("memento")),
+      :ttl   => "60"
+    },
   }
 
   dns = dns.merge(base_dns)


### PR DESCRIPTION
Alex, can you review this chef change to create a DNS entry for mementohttp. It points at the public IP addresses of the memento nodes.

Tested by running knife security groups create -E <env> locally and checking the (accurate) appearance of a mementohttp dns record.

Thanks.
