### PR TITLE
Reviewer MIRW: Add support for mangelwurzel node

### DIFF
--- a/cookbooks/clearwater/recipes/mangelwurzel.rb
+++ b/cookbooks/clearwater/recipes/mangelwurzel.rb
@@ -1,0 +1,38 @@
+# @file mangelwurzel.rb
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2013  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+package "mangelwurzel-as" do
+  action [:install]
+  options "--force-yes"
+end

--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -69,6 +69,7 @@ module Clearwater
         {:name => "enum", :security_groups => ["base", "enum"], :public_ip => true},
         {:name => "plivo", :security_groups => ["base", "internal-sip", "plivo"], :public_ip => true},
         {:name => "openimscorehss", :security_groups => ["base", "hss"]},
+        {:name => "mangelwurzel", :security_groups => ["base", "internal-sip"]},
       ]
 
     @@supported_roles = @@supported_boxes.map { |r| r[:name] }

--- a/plugins/knife/knife-box-create.rb
+++ b/plugins/knife/knife-box-create.rb
@@ -101,6 +101,7 @@ module ClearwaterKnifePlugins
         cacti: nil,
         plivo: nil,
         openimscorehss: nil,
+        mangelwurzel: nil,
         cw_aio: nil,
         cw_ami: nil
       }

--- a/roles/mangelwurzel.rb
+++ b/roles/mangelwurzel.rb
@@ -1,0 +1,40 @@
+# @file mangelwurzel.rb
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2013  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+name "mangelwurzel"
+description "mangelwurzel role"
+run_list [
+  "role[clearwater-infrastructure]",
+  "recipe[clearwater::mangelwurzel]"
+]


### PR DESCRIPTION
Hi Matt,

Please can you review my chef changes to allow us to spin up mangelwurzel nodes?

I've managed to successfully run the following test plan:
- Run knife box create -E <env> mangelwurzel
- Check a new node is created at mangelwurzel.<env>.cw-ngv.com with the mangelwurzel-as plugin installed on top of sprout-base
- Check it can receive SIP traffic on port 5058 from sprout
- Run knife box delete -E <env>-mangelwurzel and check the node has been deleted

Thanks,
Graeme
