### PR TITLE
[No review required] Remove memento_enabled and gemini_enabled from /etc/clearwater/config as...

### DIFF
--- a/cookbooks/clearwater/templates/default/config.erb
+++ b/cookbooks/clearwater/templates/default/config.erb
@@ -49,7 +49,3 @@ signup_key="<%= @node[:clearwater][:signup_key] %>"
 turn_workaround="<%= @node[:clearwater][:turn_workaround] %>"
 ellis_api_key="<%= @node[:clearwater][:ellis_api_key] %>"
 ellis_cookie_key="<%= @node[:clearwater][:ellis_cookie_key] %>"
-
-# Application servers
-memento_enabled="<%= @node[:clearwater][:memento_enabled] %>"
-gemini_enabled="<%= @node[:clearwater][:gemini_enabled] %>"


### PR DESCRIPTION
... they're no longer required
