### PR TITLE
[Reviewer: Andy] Optional Ralf

### DIFF
--- a/cookbooks/clearwater/recipes/infrastructure.rb
+++ b/cookbooks/clearwater/recipes/infrastructure.rb
@@ -117,7 +117,7 @@ unless Chef::Config[:solo]
     cdf = "cdf." + domain
   end
 
-  ralf = if node[:clearwater][:ralf] and node[:clearwater][:ralf] > 0
+  ralf = if node[:clearwater][:ralf] and ((node[:clearwater][:ralf] == true) || (node[:clearwater][:ralf] > 0))
            "ralf." + domain + ":10888"
          else
            ""

--- a/plugins/knife/knife-box-create.rb
+++ b/plugins/knife/knife-box-create.rb
@@ -74,6 +74,12 @@ module ClearwaterKnifePlugins
         end
       end)
 
+    option :ralf,
+      :long => "--with-ralf",
+      :boolean => true,     
+      :default => false,
+      :description => "Does this deployment have a Ralf?"
+
     def run()
       unless name_args.size == 1
         ui.fatal "You need to supply a box role name"
@@ -108,7 +114,7 @@ module ClearwaterKnifePlugins
       }
 
       box_manager = Clearwater::BoxManager.new(config[:cloud].to_sym, env, attributes)
-      new_box = box_manager.create_box(role, {index: config[:index], flavor: flavor_overrides[role.to_sym], ralf: config[:ralf], seagull: config[:seagull]})
+      new_box = box_manager.create_box(role, {index: config[:index], flavor: flavor_overrides[role.to_sym], ralf: ((role == "ralf") || config[:ralf]), seagull: config[:seagull]})
       instance_id = new_box.id
 
       if role == "cw_ami"

--- a/plugins/knife/knife-deployment-resize.rb
+++ b/plugins/knife/knife-deployment-resize.rb
@@ -142,7 +142,7 @@ module ClearwaterKnifePlugins
           Chef::Config[:verbosity] = config[:verbosity]
           box_create.config[:cloud] = config[:cloud]
           box_create.config[:seagull] = config[:seagull]
-          box_create.config[:ralf] = config[:ralf_count]
+          box_create.config[:ralf] = (config[:ralf_count] > 0)
           box_create.run
         rescue Exception => e
           Chef::Log.error "Failed to create node: #{e}"

--- a/plugins/knife/knife-deployment-resize.rb
+++ b/plugins/knife/knife-deployment-resize.rb
@@ -296,8 +296,8 @@ module ClearwaterKnifePlugins
 
       %w{bono ibcf sprout ralf}.each do |node_type|
         find_nodes(roles: "clearwater-infrastructure", role: node_type).each do |node|
-          has_ralf = node.set[:clearwater][:ralf]
-          puts "#{node.name}: ralf attribute is #{has_ralf} and number of ralfs is #{ralfs}"
+          has_ralf = node[:clearwater][:ralf]
+          Chef::Log.info "#{node.name}: ralf attribute is #{has_ralf} and number of ralfs is #{ralfs}"
           if (ralfs == 0) && has_ralf
             node.set[:clearwater][:ralf] = false
             node.save
@@ -314,7 +314,6 @@ module ClearwaterKnifePlugins
       unless changed_nodes.empty?
         query_string_nodes = changed_nodes.map { |n| "name:#{n}" }.join " OR "
         query_string = "chef_environment:#{environment} AND (#{query_string_nodes})"
-        puts query_string
         trigger_chef_client(cloud, query_string, true)
       end
     end
@@ -382,7 +381,7 @@ module ClearwaterKnifePlugins
         end
 
         if not bad_options.empty?
-          puts "Cannot specify --finish option with #{bad_options.join("/")}"
+          Chef::Log.error "Cannot specify --finish option with #{bad_options.join("/")}"
           return
         end
 
@@ -396,7 +395,7 @@ module ClearwaterKnifePlugins
           Chef::Log.info "Deleting quiesced boxes..."
           delete_quiesced_boxes env
         else
-          puts "#{still_quiescing} are still quiescing, can't finish (use --force to force it at the risk of data loss or call failures)'"
+          Chef::Log.error "#{still_quiescing} are still quiescing, can't finish (use --force to force it at the risk of data loss or call failures)'"
         end
 
         # Clear the "joining" attribute on all the sprouts, ralfs,
@@ -415,7 +414,7 @@ module ClearwaterKnifePlugins
           end
         end
 
-        update_ralf_hostname config[:environment], config[:cloud].to_sym
+        update_ralf_hostname(config[:environment], config[:cloud].to_sym)
         return
       end
 
@@ -459,7 +458,7 @@ module ClearwaterKnifePlugins
           unquiesce_boxes(env)
           return
         else
-          puts 'Error - you still have quiescing boxes in this deployment, so cannot perform a resize operation (other than returning the deployment to its original state). Please call "knife deployment resize -E <env> --finish" to try and complete this quiescing phase. You can see which boxes are quiescing with "knife box list -E env"'
+          Chef::Log.error 'Error - you still have quiescing boxes in this deployment, so cannot perform a resize operation (other than returning the deployment to its original state). Please call "knife deployment resize -E <env> --finish" to try and complete this quiescing phase. You can see which boxes are quiescing with "knife box list -E env"'
           return
         end
       end


### PR DESCRIPTION
This fixes https://github.com/Metaswitch/chef/issues/151 (or completes the fix to https://github.com/Metaswitch/chef/issues/124, depending on how you look at it), by making Ralf nodes genuinely optional - you can remove all Ralf nodes from a deployment, or add them in to a Ralfless deployment, and /etc/clearwater/config's ralf_hostname will adjust accordingly.

It has two parts:
* code in 'knife box create' to include a ralf_hostname if it's a Ralf node or there's a --with-ralf option - which should be uncontroversial
* code in 'knife deployment resize' to spot if we've gone from having no Ralfs to having some, or vice-versa, and update /etc/clearwater/config and restart the process on Sprout/Bono/Ralf nodes to account for that.

This second part calls 'sudo monit restart all', which means this is service-affecting - I think that's fine, because it only happens when you add Ralfs to a deployment with none (or vice versa) which will be very rare. (It should be possible to make that non-service-affecting by doing a rolling quiesce/restart, but that will be slow, and I don't think it's necessary.)

I've
* created new nodes with 'knife box create sprout --with-ralf' and 'knife box create ralf' and verified that both had a ralf_hostname set
* spun up a deployment specifying '--ralf_count 1' and verified that Sprout and Ralf had a ralf_hostname
* removed the Ralf with 'knife deployment resize --ralf-count 0 --force' and verified that Sprout's config no longer included a Ralf hostname, and was restarted (so Ralf was not in the command-line args)
* spun up a deployment without specifying ralf_count and verified that Sprout had no ralf_hostname
* subsequently run 'knife deployment resize --ralf-count 1' and verified that Sprout gained a Ralf hostname, and was restarted (so Ralf was in the command-line args), and that Ralf came up correctly
* subsequently run 'knife deployment resize --ralf-count 0' and 'knife deployment resize --finish' and verified that Sprout's config no longer included a Ralf hostname, and was restarted (so Ralf was not in the command-line args)

It's possible to fix up existing deployments like dogfood just by running "knife deployment resize" with no changes - this triggers a check that the number of Ralf nodes is consistent with the ralf attribute on existing nodes, and sets the ralf attribute if it's needed.