### PR TITLE
[Reviewer: Ellie] Set up chronos.conf file before installing Chronos

### DIFF
--- a/cookbooks/clearwater/recipes/ralf.rb
+++ b/cookbooks/clearwater/recipes/ralf.rb
@@ -1,4 +1,4 @@
-# @file sprout.rb
+# @file ralf.rb
 #
 # Project Clearwater - IMS in the Cloud
 # Copyright (C) 2013  Metaswitch Networks Ltd
@@ -31,6 +31,21 @@
 # "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
+
+directory "/etc/chronos/" do
+  owner "root"
+  group "root"
+  recursive true
+end
+
+template "/etc/chronos/chronos.conf" do
+  source "cluster/chronos.conf.erb"
+  mode 0644
+  owner "root"
+  group "root"
+  variables servers: [node],
+            localhost: node.cloud.local_ipv4
+end
 
 package "chronos" do
   action [:install]

--- a/cookbooks/clearwater/recipes/sprout.rb
+++ b/cookbooks/clearwater/recipes/sprout.rb
@@ -32,6 +32,21 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
+directory "/etc/chronos/" do
+  owner "root"
+  group "root"
+  recursive true
+end
+
+template "/etc/chronos/chronos.conf" do
+  source "cluster/chronos.conf.erb"
+  mode 0644
+  owner "root"
+  group "root"
+  variables servers: [node],
+            localhost: node.cloud.local_ipv4
+end
+
 package "chronos" do
   action [:install]
   options "--force-yes"


### PR DESCRIPTION
While testing on 14.04, I hit an issue where:
* Chronos was installed without a chronos.conf file, so bound to "localhost" by default instead of the local IP
* When clustering happened, a proper chronos.conf with the local IP is put in place - but Chronos is then SIGHUPed, which reloads the peers but doesn't rebind the HTTP stack
* Sprout then couldn't talk to Chronos

This pull request fixes that by putting a minimal chronos.conf file in place before installing Chronos. Although I hit this on 14.04 testing, I think we could hit it on 12.04 (and think this pull request is safe for 12.04), so I'd like to merge this this sprint.