### PR TITLE
Reinstate update_ralf_hostname, and remove duplicate trigger_chef_client

### DIFF
--- a/plugins/knife/cluster-boxes.rb
+++ b/plugins/knife/cluster-boxes.rb
@@ -68,42 +68,6 @@ module ClearwaterKnifePlugins
       end
     end
 
-    # Run the specified command on all nodes in the local environment that match
-    # the given `query_string`.  This should only be used for "trigger" operations,
-    # not for changing configuration - trigger_chef_client should be used for that.
-    #
-    # @param cloud [Symbol] The cloud hosting the devices.
-    # @param query_string [String] A Chef-format query string to match on.
-    # @param command [String] A shell command to run
-    def run_command(cloud, query_string, command)
-      Chef::Knife::Ssh.load_deps
-      knife_ssh = Chef::Knife::Ssh.new
-      knife_ssh.merge_configs
-      knife_ssh.config[:ssh_user] = 'ubuntu'
-      if cloud == :openstack
-        # Guard against boxes which do not have a public hostname
-        knife_ssh.config[:attribute] = 'ipaddress'
-      end
-      knife_ssh.config[:identity_file] = "#{attributes["keypair_dir"]}/#{attributes["keypair"]}.pem"
-      knife_ssh.config[:verbosity] = config[:verbosity]
-      Chef::Config[:verbosity] = config[:verbosity]
-      knife_ssh.config[:on_error] = :raise
-      knife_ssh.name_args = [
-        query_string,
-        command
-      ]
-      knife_ssh.run
-    end
-
-    # Trigger `chef-client` on all nodes in the local environment that match
-    # the given `query_string`.
-    #
-    # @param cloud [Symbol] The cloud hosting the devices.
-    # @param query_string [String] A Chef-format query string to match on.
-    def trigger_chef_client(cloud, query_string)
-      run_command(cloud, query_string, "sudo nice -n 19 chef-client")
-    end
-
     # Run the specified `astaire` command on all nodes in the local environment
     # that match the given `query_string`.
     #

--- a/plugins/knife/knife-deployment-resize.rb
+++ b/plugins/knife/knife-deployment-resize.rb
@@ -553,6 +553,8 @@ module ClearwaterKnifePlugins
           end
         end
       end
+
+      update_ralf_hostname(config[:environment], config[:cloud].to_sym)
     end
 
     def configure_dns config


### PR DESCRIPTION
@mirw, @rkd-msw I have made the following change to resolve the merge conflict that came in with the Astaire work. This change re-instates the `update_ralf_hostname` method, and refactors the code in `cluster-boxes.rb` so that there is only one copy of `trigger_chef_client`. 

Please can you both take a look and let me have any feedback by 4pm today?

I have tested this live, by running `knife deployment resize -E dogfood -V` (i.e. without changing any counts). The resize command passed without errors and the dogfood deployment now has a `ralf_hostname` set in `/etc/clearwater/config`.