### PR TITLE
[Reviewer: Andy] Scale-up/down fixes

### DIFF
--- a/plugins/knife/knife-deployment-describe.rb
+++ b/plugins/knife/knife-deployment-describe.rb
@@ -108,9 +108,9 @@ module ClearwaterKnifePlugins
         "clearwater-infrastructure" => ["clearwater-infrastructure"],
         "ellis" => ["ellis"],
         "homer" => ["homer"],
-        "ralf" => ["ralf", "chronos"],
+        "ralf" => ["ralf", "chronos", "astaire"],
         "homestead" => ["homestead"],
-        "sprout" => ["sprout", "sprout-libs", "chronos", "memento"]
+        "sprout" => ["sprout", "sprout-libs", "chronos", "memento", "astaire"]
       }
     end
 


### PR DESCRIPTION
This PR contains the following fixes:

* Add astaire to `knife deployment describe`. Tested by running the command and checking the output.
 
* Change knife to update existing DNS records where possible instead of deleting and recreating (this fixes a window condition where requesting the record before it has been recreated can cause mass call failures). Tested by doing scaling operations and checking the DNS records were updated correctly. 