### PR TITLE
[Reviewer: Ellie] GR DNS

### DIFF
--- a/cookbooks/clearwater/recipes/infrastructure.rb
+++ b/cookbooks/clearwater/recipes/infrastructure.rb
@@ -181,6 +181,10 @@ unless Chef::Config[:solo]
       variables domain: domain,
                 node: node,
                 sprout: "sprout." + domain,
+                sprout_icscf: "sprout-icscf." + domain,
+                alias_list: if node.roles.include? "sprout"
+                              "sprout-icscf." + domain
+                             end,
                 hs: "hs." + domain + ":8888",
                 hs_prov: "hs." + domain + ":8889",
                 homer: "homer." + domain + ":7888",

--- a/cookbooks/clearwater/templates/default/config.erb
+++ b/cookbooks/clearwater/templates/default/config.erb
@@ -10,6 +10,7 @@ cdf_identity=<%= @cdf %>
 sas_server=<%= @node[:clearwater][:sas_server] or "0.0.0.0" %>
 <% if not @enum.nil? %>enum_server=<%= @enum %><% end %>
 <% if not @node[:clearwater][:index].nil? %>node_idx=<%= @node[:clearwater][:index] %><% end %>
+alias_list=<%= @alias_list %>
 
 # Local IP configuration
 local_ip=<%= @node[:cloud][:local_ipv4] %>
@@ -42,11 +43,15 @@ cassandra_hostname=<%= @node[:clearwater][:cassandra_hostname] %>
 <% if @node[:clearwater][:scscf] %>scscf=<%= @node[:clearwater][:scscf] %><% end %>
 <% if @node[:clearwater][:icscf] %>icscf=<%= @node[:clearwater][:icscf] %><% end %>
 <% if @node[:clearwater][:upstream_hostname] %>upstream_hostname=<%= @node[:clearwater][:upstream_hostname] %>
-<% else %>upstream_hostname=<%= @sprout %>
+<% else %>upstream_hostname=<%= @sprout_icscf %>
 <% end %>
 <% if @node[:clearwater][:upstream_port] %>upstream_port=<%= @node[:clearwater][:upstream_port] %>
+<% else %>
+  <% if @node[:clearwater][:gr] %>upstream_port=0
 <% else %>upstream_port=5052
 <% end %>
+<% end %>
+scscf_uri="sip:<%= @sprout %>;transport=tcp"
 
 trusted_peers="<%= node[:clearwater][:trusted_peers].join "," %>"
 

--- a/cookbooks/clearwater/templates/default/config.erb
+++ b/cookbooks/clearwater/templates/default/config.erb
@@ -1,5 +1,5 @@
 # Deployment definitions
-home_domain=<%= @node[:clearwater][:gr_home_domain] or @domain %>
+home_domain=<%= @domain %>
 sprout_hostname=<%= @sprout %>
 hs_hostname=<%= @hs %>
 chronos_hostname=<%= @chronos %>
@@ -46,12 +46,11 @@ cassandra_hostname=<%= @node[:clearwater][:cassandra_hostname] %>
 <% else %>upstream_hostname=<%= @sprout_icscf %>
 <% end %>
 <% if @node[:clearwater][:upstream_port] %>upstream_port=<%= @node[:clearwater][:upstream_port] %>
-<% else %>
-  <% if @node[:clearwater][:gr] %>upstream_port=0
-<% else %>upstream_port=5052
+<% else %>upstream_port=0
 <% end %>
+<% if @scscf_uri %>
+scscf_uri="<%= @scscf_uri %>"
 <% end %>
-scscf_uri="sip:<%= @sprout %>;transport=tcp"
 
 trusted_peers="<%= node[:clearwater][:trusted_peers].join "," %>"
 

--- a/plugins/knife/clearwater-dns-records.rb
+++ b/plugins/knife/clearwater-dns-records.rb
@@ -45,6 +45,18 @@ def dns_records
       :ttl   => "60"
     },
 
+   "_sip._tcp.sprout" => {
+      :type  => "SRV",
+      :value => scscf_srv(find_active_nodes("sprout")),
+      :ttl   => "60"
+    },
+
+   "_sip._tcp.sprout-icscf" => {
+      :type  => "SRV",
+      :value => icscf_srv(find_active_nodes("sprout")),
+      :ttl   => "60"
+    },
+
     "hs" => {
       :type  => "A",
       :value => ipv4s_local(find_active_nodes("homestead")),
@@ -131,6 +143,29 @@ end
 def ipv4s_local(boxes)
   boxes.map {|n| n[:cloud][:local_ipv4]}
 end
+
+def icscf_srv(boxes)
+  boxes.map  do |n|
+    priority = if n[:clearwater][:index] % 2 == 1
+                 1
+               else
+                 2
+               end
+    "#{priority} 1 5052 #{n[:cloud][:local_ipv4]}"
+  end
+end
+
+def scscf_srv(boxes)
+  boxes.map  do |n|
+    priority = if n[:clearwater][:index] % 2 == 1
+                 1
+               else
+                 2
+               end
+    "#{priority} 1 5054 #{n[:cloud][:local_ipv4]}"
+  end
+end
+
 
 def public_hostnames(boxes)
   boxes.map {|n| n[:cloud][:public_hostname] + "."}

--- a/plugins/knife/clearwater-dns-records.rb
+++ b/plugins/knife/clearwater-dns-records.rb
@@ -47,13 +47,37 @@ def dns_records
 
    "_sip._tcp.sprout" => {
       :type  => "SRV",
-      :value => scscf_srv(find_active_nodes("sprout")),
+      :value => scscf_srv_flat(find_active_nodes("sprout")),
       :ttl   => "60"
     },
 
    "_sip._tcp.sprout-icscf" => {
       :type  => "SRV",
-      :value => icscf_srv(find_active_nodes("sprout")),
+      :value => icscf_srv_flat(find_active_nodes("sprout")),
+      :ttl   => "60"
+    },
+
+   "_sip._tcp.sprout-site1" => {
+      :type  => "SRV",
+      :value => scscf_srv_site1(find_active_nodes("sprout")),
+      :ttl   => "60"
+    },
+
+   "_sip._tcp.sprout-icscf-site1" => {
+      :type  => "SRV",
+      :value => icscf_srv_site1(find_active_nodes("sprout")),
+      :ttl   => "60"
+    },
+
+   "_sip._tcp.sprout-site2" => {
+      :type  => "SRV",
+      :value => scscf_srv_site2(find_active_nodes("sprout")),
+      :ttl   => "60"
+    },
+
+   "_sip._tcp.sprout-icscf-site2" => {
+      :type  => "SRV",
+      :value => icscf_srv_site2(find_active_nodes("sprout")),
       :ttl   => "60"
     },
 
@@ -68,6 +92,32 @@ def dns_records
       :value => ipv4s_local(find_active_nodes("homer")),
       :ttl   => "60"
     },
+
+   "hs-site1" => {
+      :type  => "A",
+      :value => ipv4s_local_site1(find_active_nodes("homestead")),
+      :ttl   => "60"
+    },
+
+    "homer-site1" => {
+      :type  => "A",
+      :value => ipv4s_local_site1(find_active_nodes("homer")),
+      :ttl   => "60"
+    },
+
+   "hs-site2" => {
+      :type  => "A",
+      :value => ipv4s_local_site2(find_active_nodes("homestead")),
+      :ttl   => "60"
+    },
+
+    "homer-site2" => {
+      :type  => "A",
+      :value => ipv4s_local_site2(find_active_nodes("homer")),
+      :ttl   => "60"
+    },
+
+
 
     "ellis" => {
       :type => "A",
@@ -89,6 +139,17 @@ def dns_records
       :value => ipv4s_local(find_active_nodes("ralf")),
       :ttl   => "60"
     },
+    "ralf-site1" => {
+      :type  => "A",
+      :value => ipv4s_local_site1(find_active_nodes("ralf")),
+      :ttl   => "60"
+    },
+    "ralf-site2" => {
+      :type  => "A",
+      :value => ipv4s_local_site2(find_active_nodes("ralf")),
+      :ttl   => "60"
+    },
+
   }
 
   memento_dns = {
@@ -144,27 +205,56 @@ def ipv4s_local(boxes)
   boxes.map {|n| n[:cloud][:local_ipv4]}
 end
 
-def icscf_srv(boxes)
+def ipv4s_local_site1(boxes)
+  boxes.select { |n| n[:clearwater][:index] % 2 == 1 }.map {|n| n[:cloud][:local_ipv4]}
+end
+
+def ipv4s_local_site2(boxes)
+  boxes.select { |n| n[:clearwater][:index] % 2 != 1 }.map {|n| n[:cloud][:local_ipv4]}
+end
+
+def icscf_srv_site1(boxes)
   boxes.map  do |n|
-    priority = if n[:clearwater][:index] % 2 == 1
-                 1
-               else
-                 2
-               end
+    priority = if n[:clearwater][:index] % 2 == 1 then 1 else 2 end
     "#{priority} 1 5052 #{n[:cloud][:local_ipv4]}"
   end
 end
 
-def scscf_srv(boxes)
+def scscf_srv_site1(boxes)
   boxes.map  do |n|
-    priority = if n[:clearwater][:index] % 2 == 1
-                 1
-               else
-                 2
-               end
+    priority = if n[:clearwater][:index] % 2 == 1 then 1 else 2 end
     "#{priority} 1 5054 #{n[:cloud][:local_ipv4]}"
   end
 end
+
+def icscf_srv_site2(boxes)
+  boxes.map  do |n|
+    priority = if n[:clearwater][:index] % 2 == 1 then 2 else 1 end
+    "#{priority} 1 5052 #{n[:cloud][:local_ipv4]}"
+  end
+end
+
+def scscf_srv_site2(boxes)
+  boxes.map  do |n|
+    priority = if n[:clearwater][:index] % 2 == 1 then 2 else 1 end
+    "#{priority} 1 5054 #{n[:cloud][:local_ipv4]}"
+  end
+end
+
+def icscf_srv_flat(boxes)
+  boxes.map  do |n|
+    priority = 1
+    "#{priority} 1 5052 #{n[:cloud][:local_ipv4]}"
+  end
+end
+
+def scscf_srv_flat(boxes)
+  boxes.map  do |n|
+    priority = 1
+    "#{priority} 1 5054 #{n[:cloud][:local_ipv4]}"
+  end
+end
+
 
 
 def public_hostnames(boxes)

--- a/plugins/knife/clearwater-dns-records.rb
+++ b/plugins/knife/clearwater-dns-records.rb
@@ -197,6 +197,10 @@ def dns_records
   return dns
 end
 
+def in_site_1?(n)
+  (n[:clearwater][:index] || 1) % 2 == 1
+end
+
 def ipv4s(boxes)
   boxes.map {|n| n[:cloud][:public_ipv4]}
 end
@@ -206,37 +210,37 @@ def ipv4s_local(boxes)
 end
 
 def ipv4s_local_site1(boxes)
-  boxes.select { |n| n[:clearwater][:index] % 2 == 1 }.map {|n| n[:cloud][:local_ipv4]}
+  boxes.select { |n| in_site_1?(n) }.map {|n| n[:cloud][:local_ipv4]}
 end
 
 def ipv4s_local_site2(boxes)
-  boxes.select { |n| n[:clearwater][:index] % 2 != 1 }.map {|n| n[:cloud][:local_ipv4]}
+  boxes.select { |n| not in_site_1?(n) }.map {|n| n[:cloud][:local_ipv4]}
 end
 
 def icscf_srv_site1(boxes)
   boxes.map  do |n|
-    priority = if n[:clearwater][:index] % 2 == 1 then 1 else 2 end
+    priority = if in_site_1?(n) then 1 else 2 end
     "#{priority} 1 5052 #{n[:cloud][:local_ipv4]}"
   end
 end
 
 def scscf_srv_site1(boxes)
   boxes.map  do |n|
-    priority = if n[:clearwater][:index] % 2 == 1 then 1 else 2 end
+    priority = if in_site_1?(n) then 1 else 2 end
     "#{priority} 1 5054 #{n[:cloud][:local_ipv4]}"
   end
 end
 
 def icscf_srv_site2(boxes)
   boxes.map  do |n|
-    priority = if n[:clearwater][:index] % 2 == 1 then 2 else 1 end
+    priority = if in_site_1?(n) then 2 else 1 end
     "#{priority} 1 5052 #{n[:cloud][:local_ipv4]}"
   end
 end
 
 def scscf_srv_site2(boxes)
   boxes.map  do |n|
-    priority = if n[:clearwater][:index] % 2 == 1 then 2 else 1 end
+    priority = if in_site_1?(n) then 2 else 1 end
     "#{priority} 1 5054 #{n[:cloud][:local_ipv4]}"
   end
 end
@@ -254,8 +258,6 @@ def scscf_srv_flat(boxes)
     "#{priority} 1 5054 #{n[:cloud][:local_ipv4]}"
   end
 end
-
-
 
 def public_hostnames(boxes)
   boxes.map {|n| n[:cloud][:public_hostname] + "."}

--- a/plugins/knife/dns-records.rb
+++ b/plugins/knife/dns-records.rb
@@ -50,6 +50,10 @@ module Clearwater
 
       # Try to get the record
       record = find_by_name_and_type(options)
+      if options[:value] == []
+        Chef::Log.info "Skipping empty record"
+        return
+      end
       if record.nil?
         create_record(options)
       else

--- a/plugins/knife/dns-records.rb
+++ b/plugins/knife/dns-records.rb
@@ -149,7 +149,7 @@ module Clearwater
         yield
       rescue Excon::Errors::BadRequest => e
         msg = Nokogiri::XML(e.response.body).xpath("//xmlns:Message").text
-        message = "Creation of #{name(options)} failed: #{msg}"
+        message = "Creation of DNS record failed: #{msg}"
         Chef::Log.error(message)
         raise e
       end


### PR DESCRIPTION
This fixes up DNS/GR stuff so that:

* Bono always uses SRV records to find Sprout
* In GR, alternate Bonos prefer different sites
* In GR, Sprout nodes only use site-local Homestead/Homer/Ralf nodes
* (In GR, your single Ellis node will only use the first site's Homer/Homestead nodes - that's probably acceptable).

I've tested by spinning up and making a basic call through a GR deployment and a non-GR deployment (checking cluster_settings in each case to check GR was as expected), and also spun up a single Sprout node to verify we don't crash if we don't have an index.