### PR TITLE
Reviewer Ellie - Various etcd fixes

### DIFF
--- a/cookbooks/clearwater/recipes/ellis.rb
+++ b/cookbooks/clearwater/recipes/ellis.rb
@@ -40,7 +40,7 @@ end
 # Perform daily backup of database
 cron "backup" do
   minute 0
-  hour 0 
+  hour 0
   command "/usr/share/clearwater/ellis/backup/do_backup.sh"
 end
 
@@ -49,10 +49,12 @@ execute "create_numbers" do
   cwd "/usr/share/clearwater/ellis/"
   command "env/bin/python src/metaswitch/ellis/tools/create_numbers.py --start #{node[:clearwater][:number_start]} --count #{node[:clearwater][:number_count]}"
   user "root"
+  only_if { ::File.exists?('/etc/clearwater/shared_config') }
 end
 
 execute "create_pstn_numbers" do
   cwd "/usr/share/clearwater/ellis/"
   command "env/bin/python src/metaswitch/ellis/tools/create_numbers.py --start #{node[:clearwater][:pstn_number_start]} --count #{node[:clearwater][:pstn_number_count]} --pstn"
   user "root"
+  only_if { ::File.exists?('/etc/clearwater/shared_config') }
 end

--- a/plugins/knife/knife-deployment-resize.rb
+++ b/plugins/knife/knife-deployment-resize.rb
@@ -456,6 +456,11 @@ module ClearwaterKnifePlugins
                             "chef_environment:#{config[:environment]} AND (#{query_strings.join(" OR ")})")
       end
 
+      # Shared config should be synchronized now, run chef-client one last time
+      # to pick up the final state.
+      trigger_chef_client(config[:cloud],
+                          "chef_environment:#{config[:environment]}")
+
       # Setup DNS zone record
       status["DNS"][:status] = "Configuring..."
       Chef::Log.info "Creating zone record..."


### PR DESCRIPTION
Fixes:

* We don't wait for etcd to come up before uploading shared config
* We don't apply shared config on `sprout-1` (or `sprout-2` in GR deployments)
* We create very bogus numbers in ellis's database