### PR TITLE
[No reviewer] Set hss

### DIFF
--- a/cookbooks/clearwater/recipes/infrastructure.rb
+++ b/cookbooks/clearwater/recipes/infrastructure.rb
@@ -142,7 +142,7 @@ unless Chef::Config[:solo]
                 ralf: "",
                 cdf: "",
                 enum: enum,
-                hss: hss,
+                hss: "",
                 etcd: node[:cloud][:local_ipv4],
                 local_site: "single_site",
                 remote_site: ""


### PR DESCRIPTION
AIO chef can't install because it has an undefined 'hss' variable. 