### PR TITLE
[Reviewer: Matt] Add in sleep statements for DNS

### DIFF
--- a/plugins/knife/dns-records.rb
+++ b/plugins/knife/dns-records.rb
@@ -174,6 +174,8 @@ module Clearwater
         record_data = make_record_data(options)
         Chef::Log.info "Creating record with config: #{record_data}"
         zone.records.create(record_data)
+        # Sleep to comply with Route53 rate-limit
+        sleep(0.2)
       end
     end
 
@@ -195,6 +197,8 @@ module Clearwater
       if record
         Chef::Log.info "Deleting record for '#{record.name}'"
         record.destroy
+        # Sleep to comply with Route53 rate-limit
+        sleep(0.2)
       end
     end
 

--- a/plugins/knife/knife-deployment-resize.rb
+++ b/plugins/knife/knife-deployment-resize.rb
@@ -461,6 +461,8 @@ module ClearwaterKnifePlugins
       trigger_chef_client(config[:cloud],
                           "chef_environment:#{config[:environment]}")
 
+      Chef::Log.info "Sleeping for 90 seconds before updating DNS to allow cluster to synchronize..."
+      sleep(90)
       # Setup DNS zone record
       status["DNS"][:status] = "Configuring..."
       Chef::Log.info "Creating zone record..."


### PR DESCRIPTION
This:
* sleeps for 200ms after each DNS request, to comply with the 5 req/sec limit (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html), fixing https://github.com/Metaswitch/chef/issues/179
* sleeps for 90 seconds before updating DNS on scale-up, mitigating https://github.com/Metaswitch/chef/issues/176

I haven't tested (but I don't often do the sort of testing that hits either problem).