### PR TITLE
Reviewer Rob - VPC support

### DIFF
--- a/VPC-SUPPORT.md
+++ b/VPC-SUPPORT.md
@@ -49,10 +49,11 @@ If you have existing VPCs and subnets and want to deploy Clearwater into them (f
 
 ## Updating your Chef environment
 
-Regardless of whether you've used the vanilla configuration or a custom setup, you should have chosen a VPC and a subnet.  Using the EC2 console, determine the ID for each of these (e.g. `vpc-123456789` and `subnet-987654321`).  Update your chef environment file (`environments/<env>.rb`) to include
+Regardless of whether you've used the vanilla configuration or a custom setup, you should have chosen a VPC and a subnet.  Using the EC2 console, determine the ID for each of these (e.g. `vpc-123456789` and `subnet-987654321`) and the availability zone of the subnet (e.g. `us-east-1a`).  Update your chef environment file (`environments/<env>.rb`) to include
 
     override_attributes "clearwater" => {
       ...
+      "availability_zones" => ["<availability_zone>"],
       "vpc" => { "vpc_id" => "<vpc_id>", "subnet_id" => "<subnet_id>" },
       ...
     }

--- a/VPC-SUPPORT.md
+++ b/VPC-SUPPORT.md
@@ -1,6 +1,6 @@
 # Amazon EC2 VPC Support
 
-Amazon EC2 offers the ability to run your instances in a Virtual Private Cloud (VPC) which allows you to fully control the networking environment, IP allocation rules, routing and firewalls.  The Chef deployment scripts in this repository support deploying Project Clearwater into a VPC but, due to the potential complexities of configuring the netwroking rules for the VPC (especially if you are attempting to use the VPC to host multiple services in multiple subnets), the scripts require you to set some configuration up front.
+Amazon EC2 offers the ability to run your instances in a Virtual Private Cloud (VPC) which allows you to fully control the networking environment, IP allocation rules, routing and firewalls.  The Chef deployment scripts in this repository support deploying Project Clearwater into a VPC but, due to the potential complexities of configuring the networking rules for the VPC (especially if you are attempting to use the VPC to host multiple services in multiple subnets), the scripts require you to set some configuration up front.
 
 ## Preparing your VPC
 
@@ -15,7 +15,7 @@ If you simply want to create a VPC dedicated to running Project Clearwater, isol
     * CIDR Block - `10.0.0.0/16`
     * Tenancy - `Default`
 1. Right-click on the newly created VPC and select "Edit DNS Hostnames"
-1. Chose "Yes" and click "Save"
+1. Choose "Yes" and click "Save"
 1. Click "Subnets" in the right-hand navigation pane
 1. Click "Create Subnet", filling in the following answers into the pop-up:
     * Name - A name for the subnet (e.g. `clearwater-subnet`)
@@ -23,12 +23,12 @@ If you simply want to create a VPC dedicated to running Project Clearwater, isol
     * Availability Zone - `No Preference`
     * CIDR Block - `10.0.0.0/16`
 1. Right-click on the newly created subnet and select "Modify Auto-assign Public IP"
-1. Check the boc and click "Save"
+1. Check the box and click "Save"
 1. Click "Internet Gateways" in the right-hand navigation pane
 1. Click "Create Internet Gateway", filling in the following answers into the pop-up:
     * Name - A name for the gateway (e.g. `clearwater-gateway`)
 1. Right-click on the newly created gateway and select "Attach to VPC"
-1. Chose the VPC you just created and click "Save"
+1. Choose the VPC you just created and click "Save"
 1. Click "Route Tables" in the right-hand navigation pane
 1. Locate the route table that is associated with your VPC
     * Optionally you might want to give this table a name to distinguish it in the dashboard
@@ -44,7 +44,7 @@ If you simply want to create a VPC dedicated to running Project Clearwater, isol
 If you have existing VPCs and subnets and want to deploy Clearwater into them (for example to allow Clearwater access to other devices in that subnet without having to route through the public internet), you will simply need to ensure that the following is true:
 
 * The VPC has "DNS hostnames" turned on.
-* The subnet has sufficient IP addresses available for your Clearwater deployment (minimum is 5).
+* The subnet has sufficient IP addresses available for your Clearwater deployment (minimum is 1 for an AIO node or 5 for a distributed install).
 * The subnet has an internet gateway and routing rules such that devices in the subnet can reach the Clearwater repository server.
 
 ## Updating your Chef environment
@@ -58,4 +58,4 @@ Regardless of whether you've used the vanilla configuration or a custom setup, y
       ...
     }
 
-Then run `knife environment from file <env>.rb` to update the chef server.  Now, future deployments will be made into the given subnet in the given VPN.
+Then run `knife environment from file <env>.rb` to update the chef server.  Now, future deployments will be created into the given subnet in the given VPN.

--- a/VPC-SUPPORT.md
+++ b/VPC-SUPPORT.md
@@ -1,0 +1,60 @@
+# Amazon EC2 VPC Support
+
+Amazon EC2 offers the ability to run your instances in a Virtual Private Cloud (VPC) which allows you to fully control the networking environment, IP allocation rules, routing and firewalls.  The Chef deployment scripts in this repository support deploying Project Clearwater into a VPC but, due to the potential complexities of configuring the netwroking rules for the VPC (especially if you are attempting to use the VPC to host multiple services in multiple subnets), the scripts require you to set some configuration up front.
+
+## Preparing your VPC
+
+### Vanilla Configuration
+
+If you simply want to create a VPC dedicated to running Project Clearwater, isolated from other services in your EC2 environment (but still accessible from the wider internet), you should follow these instructions:
+
+1. Log into your Amazon EC2 management console and navigate to the VPC Dashboard (https://console.aws.amazon.com/vpc/home)
+1. Click "Your VPCs" in the right-hand navigation pane
+1. Click "Create VPC", filling in the following answers into the pop-up:
+    * Name - A name to describe the VPC (e.g. `clearwater-vpc`)
+    * CIDR Block - `10.0.0.0/16`
+    * Tenancy - `Default`
+1. Right-click on the newly created VPC and select "Edit DNS Hostnames"
+1. Chose "Yes" and click "Save"
+1. Click "Subnets" in the right-hand navigation pane
+1. Click "Create Subnet", filling in the following answers into the pop-up:
+    * Name - A name for the subnet (e.g. `clearwater-subnet`)
+    * VPC - The VPC you just created
+    * Availability Zone - `No Preference`
+    * CIDR Block - `10.0.0.0/16`
+1. Right-click on the newly created subnet and select "Modify Auto-assign Public IP"
+1. Check the boc and click "Save"
+1. Click "Internet Gateways" in the right-hand navigation pane
+1. Click "Create Internet Gateway", filling in the following answers into the pop-up:
+    * Name - A name for the gateway (e.g. `clearwater-gateway`)
+1. Right-click on the newly created gateway and select "Attach to VPC"
+1. Chose the VPC you just created and click "Save"
+1. Click "Route Tables" in the right-hand navigation pane
+1. Locate the route table that is associated with your VPC
+    * Optionally you might want to give this table a name to distinguish it in the dashboard
+1. Click the "Routes" tab at the bottom of the screen.
+1. Click "Edit"
+1. Click "Add another route" and fill in:
+    * Destination - `0.0.0.0/0`
+    * Target - The gateway you just created
+1. Click "Save"
+
+### Specialized Configuration
+
+If you have existing VPCs and subnets and want to deploy Clearwater into them (for example to allow Clearwater access to other devices in that subnet without having to route through the public internet), you will simply need to ensure that the following is true:
+
+* The VPC has "DNS hostnames" turned on.
+* The subnet has sufficient IP addresses available for your Clearwater deployment (minimum is 5).
+* The subnet has an internet gateway and routing rules such that devices in the subnet can reach the Clearwater repository server.
+
+## Updating your Chef environment
+
+Regardless of whether you've used the vanilla configuration or a custom setup, you should have chosen a VPC and a subnet.  Using the EC2 console, determine the ID for each of these (e.g. `vpc-123456789` and `subnet-987654321`).  Update your chef environment file (`environments/<env>.rb`) to include
+
+    override_attributes "clearwater" => {
+      ...
+      "vpc" => { "vpc_id" => "<vpc_id>", "subnet_id" => "<subnet_id>" },
+      ...
+    }
+
+Then run `knife environment from file <env>.rb` to update the chef server.  Now, future deployments will be made into the given subnet in the given VPN.

--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -207,8 +207,6 @@ module Clearwater
       knife_create.config[:json_attributes][:clearwater][:ralf] = options[:ralf]
 
       # Finally, create box
-      require 'pry'
-      binding.pry
       knife_create.run
       return knife_create.server
     end

--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -153,7 +153,7 @@ module Clearwater
       # Cloud specific config
       if @cloud == :ec2
         knife_create.config[:region] = @attributes["region"]
-        knife_create.config[:availability_zone] = "us-east-1b"
+        knife_create.config[:availability_zone] = @attributes["availability_zones"].sample
 
         # If we're running in a VPC, configure the instance appropriately
         unless @attributes["vpc"].nil?

--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -155,6 +155,8 @@ module Clearwater
         knife_create.config[:region] = @attributes["region"]
         knife_create.config[:availability_zone] = "us-east-1b"
         knife_create.config[:security_group_ids] = box[:security_groups].map { |sg| translate_sg_to_id(@environment, "#{sg}-vpc-87f3d9e2") }
+        knife_create.config[:associate_public_ip] = true
+        knife_create.config[:server_connect_attribute] = "public_ip_address"
         knife_create.config[:subnet_id] = "subnet-9c148cc5"
         Chef::Config[:knife][:aws_ssh_key_id] = @attributes["keypair"]
       elsif @cloud == :openstack

--- a/plugins/knife/knife-security-groups-create.rb
+++ b/plugins/knife/knife-security-groups-create.rb
@@ -51,7 +51,7 @@ module ClearwaterKnifePlugins
 
     def run
       commission_security_groups(clearwater_security_groups,
-                                 env.name,
+                                 env,
                                  attributes["region"])
     end
   end

--- a/plugins/knife/knife-security-groups-delete.rb
+++ b/plugins/knife/knife-security-groups-delete.rb
@@ -51,7 +51,7 @@ module ClearwaterKnifePlugins
 
     def run
       delete_security_groups(clearwater_security_groups,
-                             env.name,
+                             env,
                              attributes["region"])
     end
   end

--- a/plugins/knife/security-groups.rb
+++ b/plugins/knife/security-groups.rb
@@ -217,7 +217,7 @@ module Clearwater
 
     def translate_sg_to_id(env, sg_name)
       sg = sg_api.get("#{env}-#{sg_name}")
-      fail "Couldn't find secuity group #{env}-#{sg_name}" if sg.nil?
+      fail "Couldn't find security group #{env}-#{sg_name}" if sg.nil?
       sg.group_id
     end
 

--- a/plugins/knife/security-groups.rb
+++ b/plugins/knife/security-groups.rb
@@ -48,16 +48,24 @@ module Clearwater
     end
 
     # Find or create a Security Group by name.
-    def find_or_create_group(name, description = "")
+    def find_or_create_group(name, vpc_id, description = "")
+      name = "#{name}-#{vpc_id}" unless vpc_id.nil?
       sg = sg_api.get(name)
       if sg.nil?
         puts "Creating security group: #{name}"
         sg = sg_api.new(name: name,
+                        vpc_id: vpc_id,
                         description: description)
         sg.save
         sg.reload
       end
       return sg
+    end
+
+    # Find a Security Group by name.
+    def find_group(name, vpc_id)
+      name = "#{name}-#{vpc_id}" unless vpc_id.nil?
+      return sg_api.get(name)
     end
 
     # Add a single rule to a group.
@@ -117,14 +125,16 @@ module Clearwater
       groups.each do |group_name, rules|
         group_name = "#{environment}-#{group_name}"
         sg = find_or_create_group(group_name,
+                                  "vpc-87f3d9e2",
                                   "Security group for #{group_name} nodes")
       end
 
       # Now configure the rules.
       groups.each do |group_name, rules|
         group_name = "#{environment}-#{group_name}"
-        sg = sg_api.get(group_name)
-        rules = fix_up_deployment_sg_names(rules, groups.keys, environment)
+        sg = find_group(group_name,
+                        "vpc-87f3d9e2")
+        rules = fix_up_deployment_sg_names(rules, groups.keys, environment, "vpc-87f3d9e2")
         update_security_group(sg, rules)
       end
     end
@@ -136,7 +146,7 @@ module Clearwater
       # Since we may have circular dependencies in the groups, de-configure the rules before deleting the groups
       groups.each do |group_name, rules|
         group_name = "#{environment}-#{group_name}"
-        sg = sg_api.get(group_name)
+        sg = find_group(group_name, "vpc-87f3d9e2")
         if sg
           Chef::Log.info "Deleting rules for #{group_name}"
           update_security_group(sg, [])
@@ -145,7 +155,7 @@ module Clearwater
 
       groups.each do |group_name, rules|
         group_name = "#{environment}-#{group_name}"
-        sg = sg_api.get(group_name)
+        sg = find_group(group_name, "vpc-87f3d9e2")
         if sg
           Chef::Log.info "Deleting #{group_name}"
           sg.destroy
@@ -161,9 +171,9 @@ module Clearwater
         group.ip_permissions.map do |perm|
           group_rules = perm["groups"].map do |src_group| 
             qualified_group = if group.owner_id == src_group["userId"]
-                                src_group["groupName"]
+                                src_group["groupId"]
                               else
-                                {src_group["userId"] => src_group["groupName"]}
+                                {src_group["userId"] => src_group["groupId"]}
                               end
             { min: perm["fromPort"],
               max: perm["toPort"],
@@ -184,14 +194,21 @@ module Clearwater
     end
 
     # Corrects references to other security groups to include the deployment name
-    def fix_up_deployment_sg_names(rules, known_groups, env)
+    def fix_up_deployment_sg_names(rules, known_groups, env, vpc_id)
       rules.map! do |rule|
         if rule[:group].is_a? String and known_groups.include? rule[:group]
-          rule[:group] = "#{env}-#{rule[:group]}"
+          group = "#{rule[:group]}-#{vpc_id}"
+          rule[:group] = translate_sg_to_id(env, group)
         end
         rule
       end
       rules
+    end
+
+    def translate_sg_to_id(env, sg_name)
+      sg = sg_api.get("#{env}-#{sg_name}")
+      fail if sg.nil?
+      sg.group_id
     end
 
     # The AWS Security Groups API object.

--- a/plugins/knife/trigger-chef-client.rb
+++ b/plugins/knife/trigger-chef-client.rb
@@ -47,6 +47,8 @@ module ClearwaterKnifePlugins
       knife_ssh = Chef::Knife::Ssh.new
       knife_ssh.merge_configs
       knife_ssh.config[:ssh_user] = 'ubuntu'
+
+      # Always SSH in over the public IP address
       knife_ssh.config[:attribute] = 'cloud.public_ipv4'
       if cloud == :openstack
         # Guard against boxes which do not have a public hostname

--- a/plugins/knife/trigger-chef-client.rb
+++ b/plugins/knife/trigger-chef-client.rb
@@ -42,10 +42,12 @@ module ClearwaterKnifePlugins
     # @param query_string [String] A Chef-format query string to match on.
     # @param command [String] A shell command to run
     def run_command(cloud, query_string, command)
+      Chef::Log.info "Running #{command} on #{query_string}"
       Chef::Knife::Ssh.load_deps
       knife_ssh = Chef::Knife::Ssh.new
       knife_ssh.merge_configs
       knife_ssh.config[:ssh_user] = 'ubuntu'
+      knife_ssh.config[:attribute] = 'cloud.public_ipv4'
       if cloud == :openstack
         # Guard against boxes which do not have a public hostname
         knife_ssh.config[:attribute] = 'ipaddress'


### PR DESCRIPTION
This adds support for deploying into a given subnet in a given VPC.  I'll write a README extension to describe what needs to be done to actually make use of this but the gist is:

* Set up a VPC and subnet
* Add `vpc: { vpc_id: "...", subnet_id: "..." }` to your environment file
* `knife deployment resize -E <env>`

Tested by creating/destroying deployments in a VPC and non-VPC (to check I've not broken anything in that case).