### PR TITLE
[Reviewer: Andy] Expand ability to customize flavors and images so we can have t2.micr…

### DIFF
--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -91,6 +91,8 @@ module Clearwater
       "homer" => {ec2_vpc: "t2.small"},
       "homestead" => {ec2_vpc: "t2.small"},
       "memento" => {ec2_vpc: "t2.small"},
+      "cw_aio" => {ec2_vpc: "t2.small"},
+      "cw_ami" => {ec2_vpc: "t2.small"},
     }
 
     @@default_image = {

--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -142,9 +142,9 @@ module Clearwater
         @attributes[(role + "_flavor")]
       elsif (memento and @attributes["memento_flavor"])
         @attributes["memento_flavor"]
-      elsif (gemini and @attributes[:gemini_flavor])
+      elsif (gemini and @attributes["gemini_flavor"])
         @attributes["gemini_flavor"]
-      elsif (cdiv_as and @attributes[:cdiv_as_flavor])
+      elsif (cdiv_as and @attributes["cdiv_as_flavor"])
         @attributes["cdiv_as_flavor"]
       elsif @attributes["flavor"]
         @attributes["flavor"]

--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -80,19 +80,14 @@ module Clearwater
 
     @@default_flavor = {
       ec2: "m1.small",
-      ec2_vpc: "t2.micro",
+      ec2_vpc: "t2.small",
       openstack: "2",
       rackspace: "3"
     }
 
     @@role_flavors = {
-      # Node types that use Cassandra use too much memory for a t2.micro - default those to a
-      # t2.small
-      "homer" => {ec2_vpc: "t2.small"},
-      "homestead" => {ec2_vpc: "t2.small"},
-      "memento" => {ec2_vpc: "t2.small"},
-      "cw_aio" => {ec2_vpc: "t2.small"},
-      "cw_ami" => {ec2_vpc: "t2.small"},
+      # Example:
+      # "ellis" => {ec2_vpc: "t2.micro"},
     }
 
     @@default_image = {

--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -80,8 +80,17 @@ module Clearwater
 
     @@default_flavor = {
       ec2: "m1.small",
+      ec2_vpc: "t2.micro",
       openstack: "2",
       rackspace: "3"
+    }
+
+    @@role_flavors = {
+      # Node types that use Cassandra use too much memory for a t2.micro - default those to a
+      # t2.small
+      "homer" => {ec2_vpc: "t2.small"},
+      "homestead" => {ec2_vpc: "t2.small"},
+      "memento" => {ec2_vpc: "t2.small"},
     }
 
     @@default_image = {
@@ -95,6 +104,10 @@ module Clearwater
         "ap-southeast-2" => "ami-4f274775",
         "sa-east-1" => "ami-5fbb1042",
         default: "ami-84f129f3"
+      },
+      ec2_vpc: {
+        "us-east-1" => "ami-f905f692",
+        default: "ami-f905f692",
       },
       openstack: {
         "dfw" => "5da88e4f-418f-4c5f-b148-b625071f20e6",
@@ -112,6 +125,49 @@ module Clearwater
 
     def self.supported_roles
       @@supported_roles
+    end
+
+    def choose_flavor(role)
+      cloud = @cloud
+
+      if @attributes["vpc"] and @cloud == :ec2
+        cloud = :ec2_vpc
+      end
+
+      memento = (role == "sprout" and @attributes["memento_enabled"] == "Y")
+      gemini = (role == "sprout" and @attributes["gemini_enabled"] == "Y")
+      cdiv_as = (role == "sprout" and @attributes["cdiv_as_enabled"] == "Y")
+
+      if @attributes[(role + "_flavor")]
+        @attributes[(role + "_flavor")]
+      elsif (memento and @attributes["memento_flavor"])
+        @attributes["memento_flavor"]
+      elsif (gemini and @attributes[:gemini_flavor])
+        @attributes["gemini_flavor"]
+      elsif (cdiv_as and @attributes[:cdiv_as_flavor])
+        @attributes["cdiv_as_flavor"]
+      elsif @attributes["flavor"]
+        @attributes["flavor"]
+      elsif (@@role_flavors[role] and @@role_flavors[role][@cloud])
+        @@role_flavors[role][@cloud]
+      elsif (memento and (@@role_flavors["memento"] and @@role_flavors["memento"][@cloud]))
+        @@role_flavors["memento"][@cloud]
+      else
+        @@default_flavor[@cloud]
+      end
+    end
+
+    def choose_image()
+      cloud = @cloud
+
+      if @attributes["vpc"] and @cloud == :ec2
+        cloud = :ec2_vpc
+      end
+      
+      (options[:image] or
+       @attributes["ec2_image"] or
+       @@default_image[cloud][@attributes["region"]] or
+       @@default_image[cloud][:default])
     end
 
     def create_box(role, options)
@@ -142,10 +198,8 @@ module Clearwater
       knife_create.config[:ssh_user] = "ubuntu"
 
       # Box description
-      knife_create.config[:flavor] = (options[:flavor] or @@default_flavor[@cloud])
-      knife_create.config[:image] = (options[:image] or
-                                     @@default_image[@cloud][@attributes["region"]] or
-                                     @@default_image[@cloud][:default])
+      knife_create.config[:flavor] = choose_flavor(role)
+      knife_create.config[:image] = choose_image()
       # Work around issue in knife-ec2 parameters validation
       # Have submitted patch: https://github.com/felixpalmer/knife-ec2
       Chef::Config[:knife][:image] = knife_create.config[:image]

--- a/plugins/knife/knife-box-create.rb
+++ b/plugins/knife/knife-box-create.rb
@@ -93,28 +93,8 @@ module ClearwaterKnifePlugins
         exit 1
       end
 
-      flavor_overrides = {
-        bono: nil, # or bono: "m1.large" etc...
-        ellis: nil,
-        homestead: nil,
-        homer: nil,
-        sprout: nil,
-        ibcf: nil,
-        dns: nil,
-        sipp: nil,
-        ralf: nil,
-        enum: nil,
-        cacti: nil,
-        plivo: nil,
-        openimscorehss: nil,
-        mangelwurzel: nil,
-        cw_aio: nil,
-        cw_ami: nil,
-        seagull: nil
-      }
-
       box_manager = Clearwater::BoxManager.new(config[:cloud].to_sym, env, attributes)
-      new_box = box_manager.create_box(role, {index: config[:index], flavor: flavor_overrides[role.to_sym], ralf: ((role == "ralf") || config[:ralf]), seagull: config[:seagull]})
+      new_box = box_manager.create_box(role, {index: config[:index], ralf: ((role == "ralf") || config[:ralf]), seagull: config[:seagull]})
       instance_id = new_box.id
 
       if role == "cw_ami"


### PR DESCRIPTION
…o nodes in VPCs

Should be mostly straightforward. I'm going to test by:
* spinning up a deployment in a VPC, checking it uses t2 nodes, and that I can run the live tests
* spinning up a deployment not in a VPC, checking it uses m1 nodes, and that I can run the live tests
* checking that I can use "flavor" and "ec2_image" settings in my environment to use m1.small nodes in a VPC
* checking I can use "bono_flavor" and "memento_flavor" settings in my environment to use a specific flavor for specific node types

I'm also writing something up for the team on this.