### PR TITLE
Reviewer Matt - Set security group ID in non-VPC deployments

### DIFF
--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -223,6 +223,8 @@ module Clearwater
           knife_create.config[:associate_public_ip] = true
           knife_create.config[:server_connect_attribute] = "public_ip_address"
           knife_create.config[:subnet_id] = @attributes["vpc"]["subnet_id"]
+        else
+          knife_create.config[:security_group_ids] = box[:security_groups].map { |sg| translate_sg_to_id(@environment, sg) }
         end
 
         Chef::Config[:knife][:aws_ssh_key_id] = @attributes["keypair"]


### PR DESCRIPTION
As discussed, we were not setting the security group for new nodes in non-VPC deployments.  This now sets them regardless.

You have volunteered to test.