### PR TITLE
Reviewer Alex - Support UE central 1 (Frankfurt)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    builder (3.2.0)
+    CFPropertyList (2.3.1)
+    builder (3.2.2)
     chef (11.4.0)
       erubis
       highline (>= 1.6.9)
@@ -19,20 +20,107 @@ GEM
     coderay (1.0.9)
     colored (1.2)
     erubis (2.7.0)
-    excon (0.20.1)
+    excon (0.45.3)
     facets (2.9.3)
-    fog (1.10.0)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.32.0)
+      fog-atmos
+      fog-aws (>= 0.6.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.32)
+      fog-ecloud (= 0.1.1)
+      fog-google (>= 0.0.2)
+      fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.6.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.7.2)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.32.0)
       builder
-      excon (~> 0.14)
-      formatador (~> 0.2.0)
+      excon (~> 0.45)
+      formatador (~> 0.2)
       mime-types
-      multi_json (~> 1.0)
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
-      nokogiri (~> 1.5.0)
-      ruby-hmac
-    formatador (0.2.4)
+    fog-ecloud (0.1.1)
+      fog-core
+      fog-xml
+    fog-google (0.0.6)
+      fog-core
+      fog-json
+      fog-xml
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.2.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.3)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.4)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.0.1)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.2)
+      fog-core
+      fog-json
+    fog-softlayer (0.4.7)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.1.0)
+      fission
+      fog-core
+    fog-voxel (0.1.0)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
     highline (1.6.15)
+    inflecto (0.0.2)
     ipaddress (0.8.0)
     json (1.7.7)
     knife-ec2 (0.6.2)
@@ -45,23 +133,25 @@ GEM
       chef (>= 0.10.10)
       fog (~> 1.6)
     method_source (0.8.1)
-    mime-types (1.22)
+    mime-types (2.6.1)
+    mini_portile (0.6.2)
     mixlib-authentication (1.3.0)
       mixlib-log
     mixlib-cli (1.3.0)
     mixlib-config (1.1.2)
     mixlib-log (1.4.1)
     mixlib-shellout (1.1.0)
-    multi_json (1.7.2)
-    net-scp (1.1.0)
+    multi_json (1.11.1)
+    net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.6.6)
+    net-ssh (2.9.2)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     net-ssh-multi (1.1)
       net-ssh (>= 2.1.4)
       net-ssh-gateway (>= 0.99.0)
-    nokogiri (1.5.9)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     ohai (6.16.0)
       ipaddress
       mixlib-cli
@@ -81,7 +171,6 @@ GEM
       rack
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    ruby-hmac (0.4.0)
     sinatra (1.4.2)
       rack (~> 1.5, >= 1.5.2)
       rack-protection (~> 1.4)

--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -219,12 +219,16 @@ module Clearwater
         unless @attributes["vpc"].nil?
           fail "Must specify a VPC ID to use VPC support" if @attributes["vpc"]["vpc_id"].nil?
           fail "Must specify a subnet to use VPC support" if @attributes["vpc"]["subnet_id"].nil?
-          knife_create.config[:security_group_ids] = box[:security_groups].map { |sg| translate_sg_to_id(@environment, "#{sg}-#{@attributes["vpc"]["vpc_id"]}") }
+          knife_create.config[:security_group_ids] = box[:security_groups].map do |sg|
+            translate_sg_to_id(@environment, "#{sg}-#{@attributes["vpc"]["vpc_id"]}", @attributes["region"])
+          end
           knife_create.config[:associate_public_ip] = true
           knife_create.config[:server_connect_attribute] = "public_ip_address"
           knife_create.config[:subnet_id] = @attributes["vpc"]["subnet_id"]
         else
-          knife_create.config[:security_group_ids] = box[:security_groups].map { |sg| translate_sg_to_id(@environment, sg) }
+          knife_create.config[:security_group_ids] = box[:security_groups].map do |sg|
+            translate_sg_to_id(@environment, sg, @attributes["region"])
+          end
         end
 
         Chef::Config[:knife][:aws_ssh_key_id] = @attributes["keypair"]

--- a/plugins/knife/security-groups.rb
+++ b/plugins/knife/security-groups.rb
@@ -208,14 +208,15 @@ module Clearwater
           else
             group = "#{rule[:group]}-#{vpc_id}"
           end
-          rule[:group] = translate_sg_to_id(env, group)
+          rule[:group] = translate_sg_to_id(env, group, @region)
         end
         rule
       end
       rules
     end
 
-    def translate_sg_to_id(env, sg_name)
+    def translate_sg_to_id(env, sg_name, region)
+      @region = region
       sg = sg_api.get("#{env}-#{sg_name}")
       fail "Couldn't find security group #{env}-#{sg_name}" if sg.nil?
       sg.group_id


### PR DESCRIPTION
Adds support for the newest EC2 region by taking a new `fog` version.  Also makes sure that we always know what region we're working in in case API calls are made in an unusual order.

Tested by spinning up a deployment in Frankfurt from scratch (SGs, instances, chef-client, DNS records, destruction).