### PR TITLE
[Reviewer: Andy] Allow the environment to contain extra rules for the internal-sip sec…

### DIFF
--- a/plugins/knife/clearwater-security-groups.rb
+++ b/plugins/knife/clearwater-security-groups.rb
@@ -283,11 +283,11 @@ end
 def reformat_custom_groups(map)
   (map.map do |group, ports|
     [{ ip_protocol: :tcp, min: ports[0], max: ports[1], group: group },
-    { ip_protocol: :udp, min: ports[0], max: ports[1], group: group }]
+     { ip_protocol: :udp, min: ports[0], max: ports[1], group: group }]
   end).flatten
 end
 
-def clearwater_security_groups(custom)
+def clearwater_security_groups(extra_internal_sip_groups)
   {
     "base" => base_security_group_rules,
     "repo" => repo_security_group_rules,
@@ -303,7 +303,8 @@ def clearwater_security_groups(custom)
     "cacti" => cacti_security_group_rules,
     "mmonit" => mmonit_security_group_rules,
     "perimeta" => perimeta_security_group_rules,
-    "internal-sip" => internal_sip_security_group_rules + reformat_custom_groups(custom),
+    "internal-sip" => (internal_sip_security_group_rules +
+                       reformat_custom_groups(extra_internal_sip_groups)),
     "plivo" => plivo_security_group_rules,
     "sipp" => sipp_security_group_rules,
     "hss" => hss_security_group_rules,

--- a/plugins/knife/clearwater-security-groups.rb
+++ b/plugins/knife/clearwater-security-groups.rb
@@ -280,7 +280,14 @@ def cw_aio_security_group_rules
   ]
 end
 
-def clearwater_security_groups
+def reformat_custom_groups(map)
+  (map.map do |group, ports|
+    [{ ip_protocol: :tcp, min: ports[0], max: ports[1], group: group },
+    { ip_protocol: :udp, min: ports[0], max: ports[1], group: group }]
+  end).flatten
+end
+
+def clearwater_security_groups(custom)
   {
     "base" => base_security_group_rules,
     "repo" => repo_security_group_rules,
@@ -296,7 +303,7 @@ def clearwater_security_groups
     "cacti" => cacti_security_group_rules,
     "mmonit" => mmonit_security_group_rules,
     "perimeta" => perimeta_security_group_rules,
-    "internal-sip" => internal_sip_security_group_rules,
+    "internal-sip" => internal_sip_security_group_rules + reformat_custom_groups(custom),
     "plivo" => plivo_security_group_rules,
     "sipp" => sipp_security_group_rules,
     "hss" => hss_security_group_rules,

--- a/plugins/knife/knife-security-groups-create.rb
+++ b/plugins/knife/knife-security-groups-create.rb
@@ -50,7 +50,9 @@ module ClearwaterKnifePlugins
     end
 
     def run
-      commission_security_groups(clearwater_security_groups,
+      extra_groups = attributes["extra_groups"] rescue {}
+      groups = clearwater_security_groups(extra_groups)
+      commission_security_groups(groups,
                                  env,
                                  attributes["region"])
     end

--- a/plugins/knife/knife-security-groups-create.rb
+++ b/plugins/knife/knife-security-groups-create.rb
@@ -50,7 +50,7 @@ module ClearwaterKnifePlugins
     end
 
     def run
-      extra_internal_sip_groups = attributes["extra_internal_sip_groups"] rescue {}
+      extra_internal_sip_groups = attributes["extra_internal_sip_groups"] || {}
       groups = clearwater_security_groups(extra_internal_sip_groups)
       commission_security_groups(groups,
                                  env,

--- a/plugins/knife/knife-security-groups-create.rb
+++ b/plugins/knife/knife-security-groups-create.rb
@@ -50,8 +50,8 @@ module ClearwaterKnifePlugins
     end
 
     def run
-      extra_groups = attributes["extra_groups"] rescue {}
-      groups = clearwater_security_groups(extra_groups)
+      extra_internal_sip_groups = attributes["extra_internal_sip_groups"] rescue {}
+      groups = clearwater_security_groups(extra_internal_sip_groups)
       commission_security_groups(groups,
                                  env,
                                  attributes["region"])


### PR DESCRIPTION
…urity group

This lets you specify ` "extra_groups" => {"sg-7303c000" => [5060, 5080]}` in the environment file, and have those rules added to the internal-sip security group. This is useful for interworking with SIP peers created outside of Chef - it means that the custom rules aren't overwritten when we next run 'knife security groups create'.

There are probably a few bells and whistles I could add (IP addresses, multiple port ranges) but I'd like to keep this simple for now.