### PR TITLE
[Reviewer: Rob] Minor chef fixes

### DIFF
--- a/cookbooks/clearwater/templates/default/shared_config.erb
+++ b/cookbooks/clearwater/templates/default/shared_config.erb
@@ -8,7 +8,6 @@ ralf_hostname=<%= @ralf %>
 cdf_identity=<%= @cdf %>
 sas_server=<%= @node[:clearwater][:sas_server] or "0.0.0.0" %>
 <% if not @enum.nil? %>enum_server=<%= @enum %><% end %>
-<% if not @node[:clearwater][:index].nil? %>node_idx=<%= @node[:clearwater][:index] %><% end %>
 alias_list=<%= @alias_list %>
 
 # Email server configuration

--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -347,8 +347,8 @@ def quiesce_box(box_name, env)
   
   Net::SSH.start(hostname, "ubuntu", ssh_options) do |ssh|
     ssh.exec! "sudo monit unmonitor -g etcd"
-    ssh.exec! "sudo monit unmonitor clearwater-config-manager"
-    ssh.exec! "sudo monit unmonitor clearwater-cluster-manager"
+    ssh.exec! "sudo monit unmonitor clearwater_config_manager"
+    ssh.exec! "sudo monit unmonitor clearwater_cluster_manager"
     ssh.exec! "sudo service clearwater-etcd decommission"
     case node.run_list.first.name
     when "sprout"


### PR DESCRIPTION
Minor chef fixes to not set the node_index in shared config and to use the right commands to unmonitor the cluster/config-manager. 