### PR TITLE
[Reviewer: Matt] Add alarms role

### DIFF
--- a/cookbooks/clearwater/recipes/alarms.rb
+++ b/cookbooks/clearwater/recipes/alarms.rb
@@ -1,7 +1,7 @@
-# @file call-diversion-as.rb
+# @file alarms.rb
 #
 # Project Clearwater - IMS in the Cloud
-# Copyright (C) 2014 Metaswitch Networks Ltd
+# Copyright (C) 2015  Metaswitch Networks Ltd
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -10,16 +10,16 @@
 # the program along with SSL, set forth below. This program is distributed
 # in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 # without even the implied warranty of MERCHANTABILITY or FITNESS FOR
-# A PARTICULAR PURPOSE. See the GNU General Public License for more
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
 # details. You should have received a copy of the GNU General Public
-# License along with this program. If not, see
+# License along with this program.  If not, see
 # <http://www.gnu.org/licenses/>.
 #
 # The author can be reached by email at clearwater@metaswitch.com or by
 # post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
 #
 # Special Exception
-# Metaswitch Networks Ltd grants you permission to copy, modify,
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
 # propagate, and distribute a work formed by combining OpenSSL with The
 # Software, or a work derivative of such a combination, even if such
 # copying, modification, propagation, or distribution would otherwise
@@ -32,9 +32,7 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-name "call-diversion-as"
-description "call-diversion-as role"
-run_list [
-  "role[alarms]",
-  "recipe[clearwater::call-diversion-as]"
-]
+package "clearwater-snmp-alarm-agent" do
+  action [:install]
+  options "--force-yes"
+end

--- a/cookbooks/clearwater/recipes/infrastructure.rb
+++ b/cookbooks/clearwater/recipes/infrastructure.rb
@@ -42,11 +42,6 @@ package "clearwater-snmpd" do
   options "--force-yes"
 end
 
-package "clearwater-snmp-alarm-agent" do
-  action [:install]
-  options "--force-yes"
-end
-
 if node[:clearwater][:package_update_minutes]
   package "clearwater-auto-upgrade" do
     action [:install]

--- a/roles/alarms.rb
+++ b/roles/alarms.rb
@@ -1,7 +1,7 @@
-# @file call-diversion-as.rb
+# @file alarms.rb
 #
 # Project Clearwater - IMS in the Cloud
-# Copyright (C) 2014 Metaswitch Networks Ltd
+# Copyright (C) 2015 Metaswitch Networks Ltd
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -32,9 +32,8 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-name "call-diversion-as"
-description "call-diversion-as role"
+name "alarms"
+description "alarms role"
 run_list [
-  "role[alarms]",
-  "recipe[clearwater::call-diversion-as]"
+  "recipe[clearwater::alarms]"
 ]

--- a/roles/bono.rb
+++ b/roles/bono.rb
@@ -37,6 +37,7 @@ description "bono role"
 run_list [
   "recipe[clearwater::local_config]",
   "role[clearwater-infrastructure]",
+  "role[alarms]",
   "recipe[clearwater::bono]",
   "role[clearwater-config-manager]"
 ]

--- a/roles/clearwater-config-manager.rb
+++ b/roles/clearwater-config-manager.rb
@@ -35,6 +35,6 @@
 name "clearwater-config-manager"
 description "clearwater-config-manager role"
 run_list [
+  "role[alarms]",
   "recipe[clearwater::config-manager]"
 ]
-

--- a/roles/clearwater-etcd.rb
+++ b/roles/clearwater-etcd.rb
@@ -35,5 +35,6 @@
 name "clearwater-etcd"
 description "clearwater-etcd role"
 run_list [
+  "role[alarms]",
   "recipe[clearwater::etcd]"
 ]

--- a/roles/cw_aio.rb
+++ b/roles/cw_aio.rb
@@ -36,5 +36,6 @@ name "cw_aio"
 description "cw_aio role"
 run_list [
   "role[security]",
+  "role[alarms]",
   "recipe[clearwater::cw_aio]"
 ]

--- a/roles/homestead.rb
+++ b/roles/homestead.rb
@@ -38,6 +38,7 @@ run_list [
   "recipe[clearwater::local_config]",
   "role[clearwater-infrastructure]",
   "role[cassandra]",
+  "role[alarms]",
   "recipe[clearwater::homestead]",
   "role[clearwater-etcd]",
 ]

--- a/roles/memento.rb
+++ b/roles/memento.rb
@@ -36,5 +36,6 @@ name "memento"
 description "memento role"
 run_list [
   "role[cassandra]",
+  "role[alarms]",
   "recipe[clearwater::memento]"
 ]

--- a/roles/ralf.rb
+++ b/roles/ralf.rb
@@ -37,6 +37,7 @@ description "ralf role"
 run_list [
   "recipe[clearwater::local_config]",
   "role[clearwater-infrastructure]",
+  "role[alarms]",
   "recipe[clearwater::ralf]",
   "role[clearwater-etcd]"
 ]

--- a/roles/sprout.rb
+++ b/roles/sprout.rb
@@ -37,6 +37,7 @@ description "sprout role"
 run_list [
   "recipe[clearwater::local_config]",
   "role[clearwater-infrastructure]",
+  "role[alarms]",
   "recipe[clearwater::sprout]",
   "role[clearwater-etcd]",
 ]


### PR DESCRIPTION
Split out alarms into a separate role. (We may want to convert this to a dependency later, but this stops chef installs failing)

Fixes #222 and https://github.com/Metaswitch/clearwater-snmp-handlers/issues/85