### PR TITLE
[Reviewer: Rob] Add base role

### DIFF
--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -44,6 +44,7 @@ module Clearwater
     def initialize(cloud, environment, attributes, options = {}, supported_boxes =
       [
         {:name => "clearwater-infrastructure", :security_groups => ["base"], :public_ip => true},
+        {:name => "clearwater-base", :security_groups => ["base"], :public_ip => true},
         {:name => "cw_aio", :security_groups => ["base", "cw_aio"], :public_ip => true},
         {:name => "cw_ami", :security_groups => ["base", "cw_aio"], :public_ip => true},
         {:name => "bono", :security_groups => ["base", "internal-sip", "bono"], :public_ip => true},

--- a/roles/clearwater-base.rb
+++ b/roles/clearwater-base.rb
@@ -36,6 +36,5 @@ name "clearwater-base"
 description "clearwater-base role"
 run_list [
   "recipe[clearwater::local_config]",
-  "role[clearwater-infrastructure]",
-  "role[clearwater-etcd]",
+  "role[clearwater-infrastructure]"
 ]

--- a/roles/clearwater-base.rb
+++ b/roles/clearwater-base.rb
@@ -1,0 +1,41 @@
+# @file clearwater-base.rb
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+name "clearwater-base"
+description "clearwater-base role"
+run_list [
+  "recipe[clearwater::local_config]",
+  "role[clearwater-infrastructure]",
+  "role[clearwater-etcd]",
+]


### PR DESCRIPTION
This adds a base role that just installs the local config, sets up security/certificates and installs clearwater-infrastructure. This is useful when creating a blank box for testing. 