### PR TITLE
[Reviewer: Rob] Check etcd is functional

### DIFF
--- a/plugins/knife/trigger-chef-client.rb
+++ b/plugins/knife/trigger-chef-client.rb
@@ -47,11 +47,6 @@ module ClearwaterKnifePlugins
       Chef::Knife::Ssh.load_deps
       knife_ssh = Chef::Knife::Ssh.new
 
-      # Catch the output so that we can log this at debug level not info
-      stdout = StringIO.new
-      stderr = StringIO.new
-      knife_ssh.ui = Chef::Knife::UI.new(stdout, stderr, STDIN, {})
-
       knife_ssh.merge_configs
       knife_ssh.config[:ssh_user] = 'ubuntu'
 
@@ -70,11 +65,6 @@ module ClearwaterKnifePlugins
         command
       ]
       knife_ssh.run
-
-      Chef::Log.debug "Output: #{stdout.string}"
-      if stderr.string != ''
-        Chef::Log.error "Errors: #{stderr.string}"
-      end
     end
 
     # Trigger `chef-client` on all nodes in the local environment that match


### PR DESCRIPTION
Rob, can you review this change to check that etcd is functional before trying to upload shared config. I've also taken out some code that suppressed logs - this isn't useful anymore as the etcd scripts are no longer massively spammy (they were also hiding useful logs). 

Fixes #204, and makes the chef install significantly more reliable