### PR TITLE
No reviewer

### DIFF
--- a/roles/cw_aio.rb
+++ b/roles/cw_aio.rb
@@ -36,6 +36,6 @@ name "cw_aio"
 description "cw_aio role"
 run_list [
   "role[security]",
-  "role[alarms]",
-  "recipe[clearwater::cw_aio]"
+  "recipe[clearwater::cw_aio]",
+  "role[alarms]"
 ]


### PR DESCRIPTION
swap recipie[clearwater::cw_aio] and role[alarms], to avoid dependency problems with snmpd