### PR TITLE
Reviewer RKD: Fix knife security groups delete

### DIFF
--- a/plugins/knife/knife-security-groups-delete.rb
+++ b/plugins/knife/knife-security-groups-delete.rb
@@ -50,7 +50,9 @@ module ClearwaterKnifePlugins
     end
 
     def run
-      delete_security_groups(clearwater_security_groups,
+      extra_internal_sip_groups = attributes["extra_internal_sip_groups"] || {}
+      groups = clearwater_security_groups(extra_internal_sip_groups)
+      delete_security_groups(groups,
                              env,
                              attributes["region"])
     end


### PR DESCRIPTION
Hi Rob,

Please can you review this fix to the knife security groups delete command? This matches knife-security-groups-create.rb. I was seeing the following:

```
/home/ubuntu/chef/.chef/plugins/knife/clearwater-security-groups.rb:290:in `clearwater_security_groups': wrong number of arguments (0 for 1) (ArgumentError)
```