### PR TITLE
[Reviewer: Graeme] Install clearwater-management

### DIFF
--- a/cookbooks/clearwater/recipes/shared_config.rb
+++ b/cookbooks/clearwater/recipes/shared_config.rb
@@ -34,6 +34,11 @@
 
 require 'socket'
 
+package "clearwater-management" do
+  action [:install]
+  options "--force-yes"
+end
+
 domain = if node[:clearwater][:use_subdomain]
            node.chef_environment + "." + node[:clearwater][:root_domain]
          else


### PR DESCRIPTION
If we're installing the shared config role then we need clearwater-etcd, so make sure it's installed. 