### PR TITLE
[Reviewer: Ellie] Quote the scscf_uri parameter

### DIFF
--- a/cookbooks/clearwater/templates/default/shared_config.erb
+++ b/cookbooks/clearwater/templates/default/shared_config.erb
@@ -35,7 +35,7 @@ cassandra_hostname=<%= @node[:clearwater][:cassandra_hostname] %>
 <% if @node[:clearwater][:icscf] %>icscf=<%= @node[:clearwater][:icscf] %><% end %>
 <% if @node[:clearwater][:upstream_hostname] %>upstream_hostname=<%= @node[:clearwater][:upstream_hostname] %><% else %>upstream_hostname=<%= @sprout_icscf %><% end %>
 <% if @node[:clearwater][:upstream_port] %>upstream_port=<%= @node[:clearwater][:upstream_port] %><% else %>upstream_port=0<% end %>
-<% if @scscf_uri %>scscf_uri=<%= @scscf_uri %><% end %>
+<% if @scscf_uri %>scscf_uri="<%= @scscf_uri %>"<% end %>
 
 trusted_peers="<%= node[:clearwater][:trusted_peers].join "," %>"
 


### PR DESCRIPTION
We usually set scscf_uri up with a semicolon (`sip:sprout.rkd.cw-ngv.com;transport=tcp`). If we don't quote it in the shared config, that gets lost:

`scscf_uri=sip:sprout.rkd.cw-ngv.com;transport=tcp`

is treated as:

```
scscf_uri=sip:sprout.rkd.cw-ngv.com
transport=tcp
```

With this, we'd have spotted https://github.com/Metaswitch/homestead/issues/263 earlier.