### PR TITLE
Piecemeal install updates

### DIFF
--- a/roles/bono.rb
+++ b/roles/bono.rb
@@ -35,7 +35,7 @@
 name "bono"
 description "bono role"
 run_list [
-  "recipe[clearwater::local_config]",
+  "role[local_config]",
   "role[clearwater-infrastructure]",
   "role[alarms]",
   "recipe[clearwater::bono]",

--- a/roles/bono.rb
+++ b/roles/bono.rb
@@ -39,5 +39,5 @@ run_list [
   "role[clearwater-infrastructure]",
   "role[alarms]",
   "recipe[clearwater::bono]",
-  "role[clearwater-config-manager]"
+  "role[clearwater-etcd]"
 ]

--- a/roles/call-diversion-as.rb
+++ b/roles/call-diversion-as.rb
@@ -35,6 +35,5 @@
 name "call-diversion-as"
 description "call-diversion-as role"
 run_list [
-  "role[alarms]",
   "recipe[clearwater::call-diversion-as]"
 ]

--- a/roles/clearwater-base.rb
+++ b/roles/clearwater-base.rb
@@ -35,6 +35,6 @@
 name "clearwater-base"
 description "clearwater-base role"
 run_list [
-  "recipe[clearwater::local_config]",
+  "role[local_config]",
   "role[clearwater-infrastructure]"
 ]

--- a/roles/clearwater-config-manager.rb
+++ b/roles/clearwater-config-manager.rb
@@ -35,6 +35,6 @@
 name "clearwater-config-manager"
 description "clearwater-config-manager role"
 run_list [
-  "role[alarms]",
-  "recipe[clearwater::config-manager]"
+  # Do nothing. All new work should utilise the clearwater-etcd role.
+  # This file is kept simply for back-compatibility.
 ]

--- a/roles/clearwater-etcd.rb
+++ b/roles/clearwater-etcd.rb
@@ -35,6 +35,5 @@
 name "clearwater-etcd"
 description "clearwater-etcd role"
 run_list [
-  "role[alarms]",
   "recipe[clearwater::etcd]"
 ]

--- a/roles/ellis.rb
+++ b/roles/ellis.rb
@@ -37,6 +37,7 @@ description "ellis role"
 run_list [
   "role[local_config]",
   "role[clearwater-infrastructure]",
+  "role[alarms]",
   "recipe[clearwater::ellis]",
   "role[clearwater-etcd]"
 ]

--- a/roles/ellis.rb
+++ b/roles/ellis.rb
@@ -38,5 +38,5 @@ run_list [
   "role[local_config]",
   "role[clearwater-infrastructure]",
   "recipe[clearwater::ellis]",
-  "role[clearwater-config-manager]"
+  "role[clearwater-etcd]"
 ]

--- a/roles/ellis.rb
+++ b/roles/ellis.rb
@@ -35,7 +35,7 @@
 name "ellis"
 description "ellis role"
 run_list [
-  "recipe[clearwater::local_config]",
+  "role[local_config]",
   "role[clearwater-infrastructure]",
   "recipe[clearwater::ellis]",
   "role[clearwater-config-manager]"

--- a/roles/homer.rb
+++ b/roles/homer.rb
@@ -37,6 +37,7 @@ description "homer role"
 run_list [
   "role[local_config]",
   "role[clearwater-infrastructure]",
+  "role[alarms]",
   "recipe[clearwater::homer]",
   "role[clearwater-etcd]",
 ]

--- a/roles/homestead.rb
+++ b/roles/homestead.rb
@@ -35,7 +35,7 @@
 name "homestead"
 description "homestead role"
 run_list [
-  "recipe[clearwater::local_config]",
+  "role[local_config]",
   "role[clearwater-infrastructure]",
   "role[alarms]",
   "recipe[clearwater::homestead]",

--- a/roles/local_config.rb
+++ b/roles/local_config.rb
@@ -1,7 +1,7 @@
-# @file homer.rb
+# @file local_config.rb
 #
 # Project Clearwater - IMS in the Cloud
-# Copyright (C) 2013  Metaswitch Networks Ltd
+# Copyright (C) 2015  Metaswitch Networks Ltd
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -32,11 +32,8 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-name "homer"
-description "homer role"
+name "local_config"
+description "local_config role"
 run_list [
-  "role[local_config]",
-  "role[clearwater-infrastructure]",
-  "recipe[clearwater::homer]",
-  "role[clearwater-etcd]",
+  "recipe[clearwater::local_config]",
 ]

--- a/roles/mangelwurzel.rb
+++ b/roles/mangelwurzel.rb
@@ -35,7 +35,7 @@
 name "mangelwurzel"
 description "mangelwurzel role"
 run_list [
-  "recipe[clearwater::local_config]",
+  "role[local_config]",
   "role[clearwater-infrastructure]",
   "recipe[clearwater::mangelwurzel]",
   "role[clearwater-etcd]",

--- a/roles/memento.rb
+++ b/roles/memento.rb
@@ -36,6 +36,5 @@ name "memento"
 description "memento role"
 run_list [
   "role[clearwater-infrastructure]",
-  "role[alarms]",
   "recipe[clearwater::memento]"
 ]

--- a/roles/ralf.rb
+++ b/roles/ralf.rb
@@ -35,7 +35,7 @@
 name "ralf"
 description "ralf role"
 run_list [
-  "recipe[clearwater::local_config]",
+  "role[local_config]",
   "role[clearwater-infrastructure]",
   "role[alarms]",
   "recipe[clearwater::ralf]",

--- a/roles/seagull.rb
+++ b/roles/seagull.rb
@@ -35,7 +35,7 @@
 name "seagull"
 description "seagull role"
 run_list [
-  "recipe[clearwater::local_config]",
+  "role[local_config]",
   "role[clearwater-infrastructure]",
   "recipe[clearwater::seagull]"
 ]

--- a/roles/sipp.rb
+++ b/roles/sipp.rb
@@ -35,7 +35,7 @@
 name "sipp"
 description "sipp role"
 run_list [
-  "recipe[clearwater::local_config]",
+  "role[local_config]",
   "role[clearwater-infrastructure]",
   "recipe[clearwater::etcd]",
   "recipe[clearwater::sipp]"

--- a/roles/sprout.rb
+++ b/roles/sprout.rb
@@ -35,7 +35,7 @@
 name "sprout"
 description "sprout role"
 run_list [
-  "recipe[clearwater::local_config]",
+  "role[local_config]",
   "role[clearwater-infrastructure]",
   "role[alarms]",
   "recipe[clearwater::sprout]",


### PR DESCRIPTION
Adds local_config role.
Migrates roles to clearwater-etcd rather than config-manager.
Shifts where alarms role is run.


These changes shouldn't cause any issues with back-compatibility.