### PR TITLE
[Reviewer: Andy] Ensure shared_configuration has been taken into account before creati…

### DIFF
--- a/cookbooks/clearwater/recipes/ellis.rb
+++ b/cookbooks/clearwater/recipes/ellis.rb
@@ -49,18 +49,20 @@ execute "infra_script" do
   command "service clearwater-infrastructure restart"
   user "root"
   only_if { ::File.exists?('/etc/clearwater/shared_config') }
+  notifies :run, "execute[create_numbers]", :immediately
+  notifies :run, "execute[create_pstn_numbers]", :immediately
 end
 
 execute "create_numbers" do
   cwd "/usr/share/clearwater/ellis/"
   command "env/bin/python src/metaswitch/ellis/tools/create_numbers.py --start #{node[:clearwater][:number_start]} --count #{node[:clearwater][:number_count]}"
   user "root"
-  only_if { ::File.exists?('/etc/clearwater/shared_config') }
+  action :nothing
 end
 
 execute "create_pstn_numbers" do
   cwd "/usr/share/clearwater/ellis/"
   command "env/bin/python src/metaswitch/ellis/tools/create_numbers.py --start #{node[:clearwater][:pstn_number_start]} --count #{node[:clearwater][:pstn_number_count]} --pstn"
   user "root"
-  only_if { ::File.exists?('/etc/clearwater/shared_config') }
+  action :nothing
 end

--- a/cookbooks/clearwater/recipes/ellis.rb
+++ b/cookbooks/clearwater/recipes/ellis.rb
@@ -45,6 +45,12 @@ cron "backup" do
 end
 
 # Create number pools (first normal, then PSTN)
+execute "infra_script" do
+  command "service clearwater-infrastructure restart"
+  user "root"
+  only_if { ::File.exists?('/etc/clearwater/shared_config') }
+end
+
 execute "create_numbers" do
   cwd "/usr/share/clearwater/ellis/"
   command "env/bin/python src/metaswitch/ellis/tools/create_numbers.py --start #{node[:clearwater][:number_start]} --count #{node[:clearwater][:number_count]}"


### PR DESCRIPTION
…ng numbers

This runs `service clearwater-infrastructure restart`, to ensure that /usr/share/clearwater/ellis/env/lib/python2.7/site-packages/ellis-0.1-py2.7.egg/metaswitch/ellis/local_settings.py is updated before create_numbers.py runs.

I've spun up three deployments:
- two created my full block of numbers at the right domain
- one didn't create any numbers, presumably because shared_config wasn't in place at the time - I don't think this is a regression, though, just https://github.com/Metaswitch/chef/issues/176