### PR TITLE
[Reviewer: Andy] Include AIO nodes in knife box list output

### DIFF
--- a/plugins/knife/knife-box-list.rb
+++ b/plugins/knife/knife-box-list.rb
@@ -49,7 +49,8 @@ module ClearwaterKnifePlugins
       name_glob = name_args.first
       name_glob = "*" if name_glob == "" or name_glob.nil?
       puts "Searching for node #{name_glob} in #{env}..."
-      puts "No such node" if find_nodes(name: name_glob, roles: "chef-base").each do |node|
+      nodes = find_nodes(name: name_glob, roles: "chef-base") + find_nodes(name: name_glob, roles: "cw_aio")
+      puts "No such node" if nodes.each do |node|
         if node[:ec2]
           print "Found node #{node.name} with instance-id "\
                             "#{node.ec2.instance_id} at "\


### PR DESCRIPTION
Not quite as clean as it could be, but `find_nodes` doesn't give me the fine-grained control I'd like to express "(roles:chef-base OR roles:cw_aio)" and I can't see a nice way to extend it.