### PR TITLE
[Reviewer: Alex] Move sleep around to give Ellis the best chance of creating numbers

### DIFF
--- a/plugins/knife/knife-deployment-resize.rb
+++ b/plugins/knife/knife-deployment-resize.rb
@@ -269,15 +269,17 @@ module ClearwaterKnifePlugins
                             "chef_environment:#{config[:environment]} AND (#{query_strings.join(" OR ")})")
       end
 
+      Chef::Log.info "Sleeping for 90 seconds before updating DNS to allow cluster to synchronize..."
+      sleep(90)
+
       # Shared config should be synchronized now, run chef-client one last time
-      # to pick up the final state. Sleep for 10 to give Ellis a chance to have
-      # recovered from restarting
-      sleep(10)
+      # to pick up the final state. In particular, this step is what creates
+      # numbers on ellis (which can only happen after it's picked up the shared
+      # config, so we want to do it as late as possible).
       trigger_chef_client(config[:cloud],
                           "chef_environment:#{config[:environment]}")
 
-      Chef::Log.info "Sleeping for 90 seconds before updating DNS to allow cluster to synchronize..."
-      sleep(90)
+      sleep(10)
 
       # Setup DNS zone record
       configure_dns_zone(config, attributes)


### PR DESCRIPTION
Forgot I hadn't sent this out for review. We sleep for 100 seconds near the end of `knife deployment resize` - this moves more of that 100 seconds to be before creating numbers in Ellis, to reduce the risk of it happening before we get shared config.