### PR TITLE
[Reviewer: Rob] Sleep for longer when changing DNS addresses

### DIFF
--- a/plugins/knife/dns-records.rb
+++ b/plugins/knife/dns-records.rb
@@ -50,8 +50,6 @@ module Clearwater
 
       # Try to get the record
       record = find_by_name_and_type(options)
-      # Sleep to comply with Route53 rate-limit
-      sleep(0.2)
 
       if options[:value] == []
         Chef::Log.info "Skipping empty record"
@@ -178,6 +176,9 @@ module Clearwater
         Chef::Log.info "Creating record with config: #{record_data}"
         zone.records.create(record_data)
       end
+
+      # Sleep to comply with Route53 rate-limit
+      sleep(1)
     end
 
     # Modify an existing record
@@ -187,6 +188,9 @@ module Clearwater
         Chef::Log.info "Updating record with config: #{record_data}"
         record.modify(record_data)
       end
+
+      # Sleep to comply with Route53 rate-limit
+      sleep(1)
     end
 
     # Delete a specified record
@@ -199,6 +203,9 @@ module Clearwater
         Chef::Log.info "Deleting record for '#{record.name}'"
         record.destroy
       end
+
+      # Sleep to comply with Route53 rate-limit
+      sleep(1)
     end
   end
 end


### PR DESCRIPTION
Sleep when deleting DNS records so we don't hit the AWS limit. I've also increased the time for creating and modifying records as I've been seeing rate limit errors on these as well

Fixes #268