### PR TITLE
[Reviewer: Rob] Add option to spin up S-CSCF only deployment

### DIFF
--- a/docs/knife_commands.md
+++ b/docs/knife_commands.md
@@ -28,6 +28,7 @@ To create or resize a deployment, run:
 You can optionally add:
 
 * `--<box-type>-count` - This controls how many of each box type is created. As the default, chef creates one each of a Bono, Sprout, Homer, Homestead and Ellis.
+* `--scscf-only` - This spins up the deployment with I-CSCF function disabled.
 
 As well as passing in parameters to the `deployment resize` command, you can also set options in the `override_attributes` section of the environment file. The available options are discussed [here](http://clearwater.readthedocs.org/en/stable/Creating_a_deployment_environment/index.html#creating-the-environment); the notable ones are:
 

--- a/plugins/knife/knife-deployment-resize.rb
+++ b/plugins/knife/knife-deployment-resize.rb
@@ -262,7 +262,7 @@ module ClearwaterKnifePlugins
           s_node.run_list << "role[shared_config]"
 
           if config[:scscf_only]
-            s_node.set[:clearwater][:upstream_hostname] = "sip:scscf.$sprout_hostname:5054;transport=tcp"
+            s_node.set[:clearwater][:upstream_hostname] = "scscf.$sprout_hostname"
             s_node.set[:clearwater][:upstream_port] = 5054
             s_node.set[:clearwater][:icscf] = 0
           end

--- a/plugins/knife/knife-deployment-resize.rb
+++ b/plugins/knife/knife-deployment-resize.rb
@@ -98,6 +98,10 @@ module ClearwaterKnifePlugins
       :long => "--start",
       :description => "Starts a new resize operation."
 
+    option :scscf_only,
+      :long => "--scscf-only",
+      :description => "Spins up the deployment with I-CSCF disabled."
+
     # Auto-scaling parameters
     #
     # Scaling limits calculated from scaling tests on m1.small EC2 instances.
@@ -256,6 +260,13 @@ module ClearwaterKnifePlugins
 
         for s_node in s_nodes
           s_node.run_list << "role[shared_config]"
+
+          if config[:scscf_only]
+            s_node.set[:clearwater][:upstream_hostname] = "sip:scscf.$sprout_hostname:5054;transport=tcp"
+            s_node.set[:clearwater][:upstream_port] = 5054
+            s_node.set[:clearwater][:icscf] = 0
+          end
+
           s_node.save
         end
 


### PR DESCRIPTION
This PR adds support for an easy way to spin up a deployment with I-CSCF disabled.

Part of enabling I-CSCF function by default.