### PR TITLE
[Reviewer: Alex] Print a note about the AIO signup key

### DIFF
--- a/plugins/knife/knife-box-create.rb
+++ b/plugins/knife/knife-box-create.rb
@@ -123,6 +123,10 @@ module ClearwaterKnifePlugins
         end
       end
 
+      if role == "cw_aio"
+        puts "Note: The signup code for AIO nodes is 'secret', not the value configured in knife.rb"
+      end
+
       if role == "cw_ami"
         ec2_conn = Fog::Compute::AWS.new(Chef::Config[:knife].select { |k, v| [:aws_secret_access_key, :aws_access_key_id].include? k })
         ec2_conn.stop_instances(instance_id)


### PR DESCRIPTION
Fixes #278 - I'll also add a note to http://docs.projectclearwater.org/en/stable/Creating_a_deployment_with_Chef.html#creating-an-all-in-one-aio-node.

I've tested:

```
...
Environment: rkd
Run List: role[cw_aio]
JSON Attributes: {:clearwater=>{:seagull=>nil, :ralf=>false}}
Note: The signup code for AIO nodes is 'secret', not the value configured in knife.rb
```