### PR TITLE
[Reviewer: EM] Only request the record we want instead of all!

### DIFF
--- a/plugins/knife/dns-records.rb
+++ b/plugins/knife/dns-records.rb
@@ -111,9 +111,7 @@ module Clearwater
     private
 
     def find_by_name_and_type(options)
-      zone.records.all!.select do |r|
-        r.name == name(options) and r.type.upcase == options[:type].upcase
-      end.first
+      zone.records.get(name(options), options[:type])
     end
 
     def calculate_options_from_node(node)


### PR DESCRIPTION
This resolves some problems we've been seeing with throttling on Route 53.

The all! call in fog-aws causes us to request all the records in the zone. This works by repeatedly requesting a page of records at a time, where with a large zone causes a large number of pages to be requested. It's also not concurrently safe as a change may be made between pages being requested.

This resolves this by using the correct call on fog, which allows us to ask for the record we actually want instead of all of the records, which makes it much quicker, and hugely reduces the number of requests required.

This call has been in fog-aws since at least 0.6.0, so we don't need to upgrade fog-aws - see https://github.com/fog/fog-aws/blob/v0.6.0/lib/fog/aws/models/dns/records.rb#L67-L104