### PR TITLE
Reviewer AJL: Split storage fixes post-Cassandra schema testing

### DIFF
--- a/cookbooks/clearwater/recipes/database.rb
+++ b/cookbooks/clearwater/recipes/database.rb
@@ -36,3 +36,7 @@ package "atlas-node" do
   action [:install]
   options "--force-yes"
 end
+package "homestead-prov-cassandra" do
+  action [:install]
+  options "--force-yes"
+end

--- a/cookbooks/clearwater/recipes/homer.rb
+++ b/cookbooks/clearwater/recipes/homer.rb
@@ -32,7 +32,7 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-package "homer" do
+package "homer-node" do
   action [:install]
   options "--force-yes"
 end

--- a/cookbooks/clearwater/recipes/homestead.rb
+++ b/cookbooks/clearwater/recipes/homestead.rb
@@ -46,10 +46,6 @@ else
     action [:install]
     options "--force-yes"
   end
-  package "homestead-node-prov" do
-    action [:install]
-    options "--force-yes"
-  end
 end
 
 package "clearwater-snmp-handler-homestead" do


### PR DESCRIPTION
***This PR is currently based against the split-storage-packages branch - if that branch has already been merged into dev this branch should also be merged into dev***

A few fixes that I think we need.
* I think the database node should install the homestead-prov schema. We don't install it by default (i.e. it's not a dependency of atlas-node) because we don't want it if we're running with an HSS, but generally when we're using chef we don't have an HSS and there is no harm in installing it.
* The homer recipe should now install homer-node.
* The homestead recipe shouldn't install homestead-node-prov because that isn't a thing.