### PR TITLE
[Reviewer: RKD] Homestead-prov, Homer and Memento split-storage

### DIFF
--- a/cookbooks/clearwater/recipes/homer.rb
+++ b/cookbooks/clearwater/recipes/homer.rb
@@ -32,14 +32,21 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-package "homer-node" do
-  action [:install]
-  options "--force-yes"
+if node[:clearwater][:split_storage]
+  package "homer" do
+    action [:install]
+    options "--force-yes"
+  end
+else
+  package "homer-node" do
+    action [:install]
+    options "--force-yes"
+  end
 end
 
 # Perform daily backup of database
 cron "backup" do
-  hour 0 
+  hour 0
   minute 0
   command "/usr/share/clearwater/bin/do_backup.sh homer"
 end

--- a/cookbooks/clearwater/recipes/memento.rb
+++ b/cookbooks/clearwater/recipes/memento.rb
@@ -32,14 +32,20 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-package "memento-nginx" do
-  action [:install]
-  options "--force-yes"
-end
-
-package "memento-as" do
-  action [:install]
-  options "--force-yes"
+if node[:clearwater][:split_storage]
+  package "memento-nginx" do
+    action [:install]
+    options "--force-yes"
+  end
+  package "memento-as" do
+    action [:install]
+    options "--force-yes"
+  end
+else
+  package "memento-node" do
+    action [:install]
+    options "--force-yes"
+  end
 end
 
 # Perform daily backup of database

--- a/cookbooks/clearwater/recipes/vellum.rb
+++ b/cookbooks/clearwater/recipes/vellum.rb
@@ -36,7 +36,12 @@ package "vellum-node" do
   action [:install]
   options "--force-yes"
 end
-package "homestead-prov-cassandra" do
+package "homer-cassandra" do
   action [:install]
   options "--force-yes"
 end
+package "memento-cassandra" do
+  action [:install]
+  options "--force-yes"
+end
+

--- a/cookbooks/clearwater/templates/default/shared_config.erb
+++ b/cookbooks/clearwater/templates/default/shared_config.erb
@@ -49,6 +49,7 @@ hss_port=<%= @node[:clearwater][:hss_port] %>
 trusted_peers="<%= node[:clearwater][:trusted_peers].join "," %>"
 
 # Sproutlet configuration
+<%# We use, for example, @node{:clearwater][:icscf] to override the fields below in the environment file. %>
 <% if @node[:clearwater][:scscf] %>scscf=<%= @node[:clearwater][:scscf] %><% end %>
 <% if @node[:clearwater][:icscf] %>icscf=<%= @node[:clearwater][:icscf] %><% end %>
 <% if @node[:clearwater][:bgcf] %>bgcf=<%= @node[:clearwater][:bgcf] %><% end %>

--- a/cookbooks/clearwater/templates/default/shared_config.erb
+++ b/cookbooks/clearwater/templates/default/shared_config.erb
@@ -52,9 +52,9 @@ trusted_peers="<%= node[:clearwater][:trusted_peers].join "," %>"
 <% if @node[:clearwater][:scscf] %>scscf=<%= @node[:clearwater][:scscf] %><% end %>
 <% if @node[:clearwater][:icscf] %>icscf=<%= @node[:clearwater][:icscf] %><% end %>
 <% if @node[:clearwater][:bgcf] %>bgcf=<%= @node[:clearwater][:bgcf] %><% end %>
-<% if @node[:clearwater][:memento] %>memento=<%= @node[:clearwater][:memento] %><% end %>
-<% if @node[:clearwater][:gemini] %>gemini=<%= @node[:clearwater][:gemini] %><% end %>
-<% if @node[:clearwater][:cdiv] %>cdiv=<%= @node[:clearwater][:cdiv] %><% end %>
+memento=<%= @node[:clearwater][:memento] or "5055" %>
+gemini=<%= @node[:clearwater][:gemini] or "5055" %>
+cdiv=<%= @node[:clearwater][:cdiv] or "5055" %>
 <% if @node[:clearwater][:mmtel] %>mmtel=<%= @node[:clearwater][:mmtel] %><% end %>
 <% if @node[:clearwater][:mangelwurzel] %>mangelwurzel=<%= @node[:clearwater][:mangelwurzel] %><% end %>
 


### PR DESCRIPTION
Use the appropriate packages for Homer/Memento depending on whether we are in split-storage or not.

Install the homer-cassandra and memento-cassandra packages onto the Vellum node (homested-prov-cassandra is already installed by the debian dependencies).

Tested that this spins up a working split-storage deployment, with passing live tests.