### PR TITLE
[Reviewer: Sathiyan] Clean out historical security groups

### DIFF
--- a/plugins/knife/knife-security-groups-delete.rb
+++ b/plugins/knife/knife-security-groups-delete.rb
@@ -52,6 +52,14 @@ module ClearwaterKnifePlugins
     def run
       extra_internal_sip_groups = attributes["extra_internal_sip_groups"] || {}
       groups = clearwater_security_groups(extra_internal_sip_groups)
+
+      historical_groups = ["database"]
+      historical_groups.each do |g|
+        # We don't need to specify any rules - this entry just makes sure we
+        # delete the group
+        groups[g] = []
+      end
+
       delete_security_groups(groups,
                              env,
                              attributes["region"])


### PR DESCRIPTION
This change means that if you delete security groups after pulling the new Chef code, it'll work, so you don't have to make sure to run `knife security groups delete` before a `git pull` - this feels cleaner.