### PR TITLE
[Reviewer: Graeme] Expose the homestead and sprout management APIs

### DIFF
--- a/cookbooks/clearwater/recipes/shared_config.rb
+++ b/cookbooks/clearwater/recipes/shared_config.rb
@@ -84,10 +84,12 @@ template "/etc/clearwater/shared_config" do
   variables domain: domain,
     node: node,
     sprout: "sprout#{site_suffix}.#{domain}",
+    sprout_mgmt: "sprout#{site_suffix}.#{domain}:9886",
     alias_list: if node.roles.include? "sprout"
                   sprout_aliases.join(",")
                 end,
     hs: "hs#{site_suffix}.#{domain}:8888",
+    hs_mgmt: "hs#{site_suffix}.#{domain}:8886",
     hs_prov: "hs#{site_suffix}.#{domain}:8889",
     homer: "homer#{site_suffix}.#{domain}:7888",
     ralf: ralf,

--- a/cookbooks/clearwater/templates/default/shared_config.erb
+++ b/cookbooks/clearwater/templates/default/shared_config.erb
@@ -1,7 +1,9 @@
 # Deployment definitions
 home_domain=<%= @domain %>
 sprout_hostname=<%= @sprout %>
+sprout_mgmt_hostname=<%= @sprout_mgmt %>
 hs_hostname=<%= @hs %>
+hs_mgmt_hostname=<%= @hs_mgmt %>
 hs_provisioning_hostname=<%= @hs_prov %>
 xdms_hostname=<%= @homer %>
 ralf_hostname=<%= @ralf %>

--- a/plugins/knife/clearwater-security-groups.rb
+++ b/plugins/knife/clearwater-security-groups.rb
@@ -142,6 +142,8 @@ def sprout_security_group_rules
       { ip_protocol: :tcp, min: 9888, max: 9888, group: "sprout" },
       # Homestead deregistration interface
       { ip_protocol: :tcp, min: 9888, max: 9888, group: "homestead" },
+      # Mangement HTTP API
+      { ip_protocol: :tcp, min: 9886, max: 9886, group: "base" },
     ]
 end
 
@@ -155,6 +157,8 @@ def homestead_security_group_rules
       # Cassandra
       { ip_protocol: :tcp, min: 7000, max: 7000, group: "homestead" },
       { ip_protocol: :tcp, min: 9160, max: 9160, group: "homestead" },
+      # Mangement HTTP API
+      { ip_protocol: :tcp, min: 8886, max: 8886, group: "base" },
     ]
 end
 


### PR DESCRIPTION
Please can you review this chef change to expose the new management APIs. I've tested this live by checking:

* I can query the list of IMPUs from a sprout node using `$hs_mgmt_hostname`. 
* I can query a subscriber's bindings from a homestead node using `$sprout_mgmt_hostname`. 