### PR TITLE
[Reviewer: Adam] Add default billing realm value

### DIFF
--- a/cookbooks/clearwater/templates/default/shared_config.erb
+++ b/cookbooks/clearwater/templates/default/shared_config.erb
@@ -40,7 +40,7 @@ hss_port=<%= @node[:clearwater][:hss_port] %>
 <% if not @node[:clearwater][:hss_realm].nil? %>hss_realm=<%= @node[:clearwater][:hss_realm] %><% end %>
 
 # CDF configuration
-<% if not @node[:clearwater][:billing_realm].nil? %>billing_realm=<%= @node[:clearwater][:billing_realm] %><% end %>
+<% if not @node[:clearwater][:billing_realm].nil? %>billing_realm=<%= @node[:clearwater][:billing_realm] %><% else %>billing_realm=<%= @cdf %><% end %>
 
 # Registrar configuration
 <% if @node[:clearwater][:reg_max_expires] %>reg_max_expires=<%= @node[:clearwater][:reg_max_expires] %><% end %>


### PR DESCRIPTION
Add a default billing realm value if nothing has been set. This value can still be overridden in the environment file, and doesn't change anything if there are no Ralfs in the deployment.

Tested live