### PR TITLE
[Reviewer: Ellie] Prevent erroneous confirmation on resize

### DIFF
--- a/plugins/knife/knife-deployment-resize.rb
+++ b/plugins/knife/knife-deployment-resize.rb
@@ -208,6 +208,9 @@ module ClearwaterKnifePlugins
           new_counts.delete(:ralf)
           new_counts[:dime] = config[:dime_count] || [old_counts[:dime], 1].max
           config[:dime_count] = new_counts[:dime]
+        else
+          new_counts[:vellum] = old_counts[:vellum]
+          new_counts[:dime] = old_counts[:dime]
         end
 
       # Confirm changes if there are any


### PR DESCRIPTION
If we aren't using split storage, we need to initialize the dime and vellum  counts to their current values so that the hashes match.

Otherwise we have:

{:bono=>1, :ellis=>1, :ibcf=>0, :homer=>1, :homestead=>1, :sprout=>1, :sipp=>0, :ralf=>0, :seagull=>0, :vellum=>0, :dime=>0}

compared against

{:ellis=>1, :bono=>1, :homestead=>1, :ralf=>0, :homer=>1, :sprout=>1, :ibcf=>0, :sipp=>0, :seagull=>0}

which doesn't match, which causes it to print the following pointless confirmation prompt:

```
$ knife deployment resize -E environment
Continue? (y/N)
```
