### PR TITLE
[No Reviewer] Do not run sprout-only upload scripts on startup

### DIFF
--- a/cookbooks/clearwater/recipes/shared_config.rb
+++ b/cookbooks/clearwater/recipes/shared_config.rb
@@ -114,13 +114,6 @@ ruby_block "wait_for_etcd" do
   notifies :run, "execute[poll_etcd]", :immediately
   notifies :run, "execute[upload_shared_config]", :immediately
 
-  # Only run the extra etcd scripts if we're on a Sprout node
-  if node.run_list.any? { |s| s.to_s.include?('sprout') }
-    notifies :run, "execute[upload_enum_json]", :immediately
-    notifies :run, "execute[upload_bgcf_json]", :immediately
-    notifies :run, "execute[upload_scscf_json]", :immediately
-  end
-
   action :nothing
 end
 

--- a/cookbooks/clearwater/recipes/shared_config.rb
+++ b/cookbooks/clearwater/recipes/shared_config.rb
@@ -130,21 +130,3 @@ execute "upload_shared_config" do
   command "/usr/share/clearwater/clearwater-config-manager/scripts/upload_shared_config"
   action :nothing
 end
-
-execute "upload_enum_json" do
-  user "root"
-  command "/usr/share/clearwater/clearwater-config-manager/scripts/upload_enum_json"
-  action :nothing
-end
-
-execute "upload_bgcf_json" do
-  user "root"
-  command "/usr/share/clearwater/clearwater-config-manager/scripts/upload_bgcf_json"
-  action :nothing
-end
-
-execute "upload_scscf_json" do
-  user "root"
-  command "/usr/share/clearwater/clearwater-config-manager/scripts/upload_scscf_json"
-  action :nothing
-end


### PR DESCRIPTION
Stops us from running upload_blah.json on sprout nodes, as the plugins now create and upload default template files if none are already preset.
We still want to run upload shared config though, so that deployments come up alive and running. 