### PR TITLE
[Reviewer: Seb] Add signaling command to backups

### DIFF
--- a/cookbooks/clearwater/recipes/homer.rb
+++ b/cookbooks/clearwater/recipes/homer.rb
@@ -48,5 +48,5 @@ end
 cron "backup" do
   hour 0
   minute 0
-  command "/usr/share/clearwater/bin/do_backup.sh homer"
+  command "/usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homer"
 end

--- a/cookbooks/clearwater/recipes/homestead.rb
+++ b/cookbooks/clearwater/recipes/homestead.rb
@@ -51,10 +51,10 @@ end
 cron "backup" do
   hour 0
   minute 0
-  command "/usr/share/clearwater/bin/do_backup.sh homestead_provisioning"
+  command "/usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homestead_provisioning"
 end
 cron "backup_cache" do
   hour 0
   minute 5
-  command "/usr/share/clearwater/bin/do_backup.sh homestead_cache"
+  command "/usr/share/clearwater/bin/run-in-signaling-namespace /usr/share/clearwater/bin/do_backup.sh homestead_cache"
 end


### PR DESCRIPTION
Fix the do_backup commands so that they do run in the signaling namespace