### PR TITLE
[Reviewer: Adam] split-clusters fixes

### DIFF
--- a/cookbooks/clearwater/recipes/shared_config.rb
+++ b/cookbooks/clearwater/recipes/shared_config.rb
@@ -87,10 +87,6 @@ else
     ralf_session_store = "#{ralf_session_store},site#{i}=ralf-site#{i}.#{domain}"
   end
 
-  sprout_impi_store = "localhost"
-  chronos_hostname = "localhost"
-  cassandra_hostname = "localhost"
-
   if node[:clearwater][:ralf] and ((node[:clearwater][:ralf] == true) || (node[:clearwater][:ralf] > 0))
     ralf = "ralf#{site_suffix}.#{domain}:10888"
   end

--- a/plugins/knife/knife-deployment-utils.rb
+++ b/plugins/knife/knife-deployment-utils.rb
@@ -54,7 +54,7 @@ module ClearwaterKnifePlugins
           Chef::Config[:verbosity] = config[:verbosity]
           box_create.config[:cloud] = config[:cloud]
           box_create.config[:seagull] = config[:seagull]
-          box_create.config[:ralf] = (config[:ralf_count] and (config[:ralf_count] > 0))
+          box_create.config[:ralf] = (config[:ralf_count] and (config[:ralf_count].to_i > 0))
           box_create.run(supported_boxes)
         rescue Exception => e
           Chef::Log.error "Failed to create node: #{e}"


### PR DESCRIPTION
Some small changes to chef for a non-GR deployment:

 - don't set chronos_hostname, sprout_impi_store or cassandra_hostname if not
   using split-storage (just use the defaults)
 - fix error when trying to deploy ralf

Tested that it spins up a new-style deployment correctly and live tests pass against it