### PR TITLE
[Reviewer: Seb] Move site_names and rename

### DIFF
--- a/cookbooks/clearwater/recipes/local_config.rb
+++ b/cookbooks/clearwater/recipes/local_config.rb
@@ -33,10 +33,6 @@ if node[:clearwater][:num_gr_sites] && node[:clearwater][:num_gr_sites] > 1 && n
   local_site_index = node[:clearwater][:site]
   local_site = sites[local_site_index - 1]
 
-  # Remove the local site to get the list of remote sites.
-  sites.delete_at(local_site_index - 1)
-  remote_sites = sites.join(",")
-
   # List all nodes in the remote sites as the remote_cassandra_nodes. This means
   # remote_cassandra_seeds will be set on all nodes (even though it's only ever
   # used on nodes with Cassandra).
@@ -81,6 +77,5 @@ template "/etc/clearwater/local_config" do
               etcd_cluster_or_proxy: etcd_cluster_or_proxy,
               etcd: etcd,
               local_site: local_site,
-              remote_sites: remote_sites,
               remote_cassandra_nodes: remote_cassandra_nodes
 end

--- a/cookbooks/clearwater/recipes/shared_config.rb
+++ b/cookbooks/clearwater/recipes/shared_config.rb
@@ -30,8 +30,18 @@ end
 
 if node[:clearwater][:num_gr_sites]
   number_of_sites = node[:clearwater][:num_gr_sites]
+
+  # Set up an array of all the sites.
+  sites = Array.new(number_of_sites)
+  for i in 0...number_of_sites
+      sites[i] = "site#{i+1}"
+  end
+
+  site_names = sites.join(",")
+
 else
   number_of_sites = 1
+  site_names = ""
 end
 
 site_suffix = if number_of_sites > 1 && node[:clearwater][:site]
@@ -47,7 +57,6 @@ for i in 2..number_of_sites
   ralf_session_store = "#{ralf_session_store},site#{i}=vellum-site#{i}.#{domain}"
 end
 
-sprout_impi_store = "vellum#{site_suffix}.#{domain}"
 chronos_hostname = "vellum#{site_suffix}.#{domain}"
 cassandra_hostname = "vellum#{site_suffix}.#{domain}"
 
@@ -80,12 +89,12 @@ template "/etc/clearwater/shared_config" do
     hss: hss,
     cassandra_hostname: cassandra_hostname,
     chronos_hostname: chronos_hostname,
-    sprout_impi_store: sprout_impi_store,
     sprout_registration_store: sprout_registration_store,
     ralf_session_store: ralf_session_store,
     memento_auth_store: "vellum#{site_suffix}.#{domain}",
     scscf_uri: "sip:scscf.sprout#{site_suffix}.#{domain}",
     upstream_port: 0
+    site_names: site_names,
   notifies :run, "ruby_block[wait_for_etcd]", :immediately
 end
 

--- a/cookbooks/clearwater/templates/default/local_config.erb
+++ b/cookbooks/clearwater/templates/default/local_config.erb
@@ -8,7 +8,6 @@ public_hostname=<%= @node[:cloud][:public_hostname] %>
 
 # GR configuration
 local_site_name=<%= @local_site %>
-remote_site_names=<%= @remote_sites %>
 remote_cassandra_seeds=<%= @remote_cassandra_nodes.map{|n| n.cloud.local_ipv4}.join "," %>
 
 # etcd configuration

--- a/cookbooks/clearwater/templates/default/shared_config.erb
+++ b/cookbooks/clearwater/templates/default/shared_config.erb
@@ -8,7 +8,6 @@ hs_provisioning_hostname=<%= @hs_prov %>
 xdms_hostname=<%= @homer %>
 ralf_hostname=<%= @ralf %>
 cdf_identity=<%= @cdf %>
-sprout_impi_store=<%= @sprout_impi_store %>
 sprout_registration_store=<%= @sprout_registration_store %>
 cassandra_hostname=<%= @cassandra_hostname %>
 chronos_hostname=<%= @chronos_hostname %>
@@ -61,3 +60,6 @@ ellis_cookie_key="<%= @node[:clearwater][:ellis_cookie_key] %>"
 
 # Advanced options
 nonce_count_supported=Y
+
+# GR options
+site_names=<%= @site_names %>


### PR DESCRIPTION
This moves remote_site_names to shared_config, renames it to site_names, and puts all site names into the configuration value rather than excluding the local_site_name.

I've also taken out the sprout_impi_store, as we don't expect to set this by default.