### PR TITLE
Chef only puts one node in etcd cluster by default

### DIFF
--- a/cookbooks/clearwater/recipes/local_config.rb
+++ b/cookbooks/clearwater/recipes/local_config.rb
@@ -67,7 +67,10 @@ else
   end
 end
 
-if node.role?("vellum")
+# Count the vellum nodes in the local etcd cluster
+vellum_count = etcd.count { |n| n.role?("vellum") }
+
+if node.role?("vellum") || vellum_count <= 1
   etcd_cluster_or_proxy = "etcd_cluster"
 else
   etcd_cluster_or_proxy = "etcd_proxy"


### PR DESCRIPTION
If you use chef to spin up a minimal Clearwater deployment, with the default numbers of servers, then only one of them (the single vellum node) will be put in the etcd cluster.  All other servers will act as etcd proxies.  If we have a pool containing multiple vellum servers, then this would be the correct behaviour.  When we only have one, we should put other servers in the etcd cluster, too.  Salinas puts all servers in the etcd cluster if there is only one vellum node, so I've done the same here.

This addresses the underlying problem behind Houdini issue [693](https://github.com/Metaswitch/houdini/issues/693).  If there is only one node in your etcd cluster, then we have timing windows on upgrade, where the clearwater-etcd process can get into a pickle.  Having multiple nodes in the cluster prevent this.