### PR TITLE
[Reviewer: EM] Improve expand_hashes function

### DIFF
--- a/plugins/knife/knife-clearwater-utils.rb
+++ b/plugins/knife/knife-clearwater-utils.rb
@@ -78,10 +78,20 @@ module ClearwaterKnifePlugins
       end
     end
 
-    # Expands out hashes of boxes, e.g. {:bono => 3} becomes:
-    # {{:role => "bono", :index => 1}, {:role => "bono", :index = 2}, etc...
+    # Expands out hashes of boxes, e.g. {:bono-site1 => 3} becomes:
+    # {{:role => "bono", :site => 1, :index => 1},
+    # {:role => "bono", :site => 1, :index = 2}, etc...
     def expand_hashes(boxes)
-      boxes.map {|box, n| (1..n).map {|i| {:role => box.to_s.split("-site")[0].to_s, :site => box.to_s.split("-site")[1].to_i, :index => i}}}.flatten
+      boxes.map {|box, n| (1..n).map {|i| expand_hash(box, i)}}.flatten
+    end
+
+    # Helper for the previous function. Checks that the passed hash has the
+    # correct form.
+    def expand_hash(box, index)
+      box_split = box.to_s.split("-site")
+      raise ArgumentError, "box hash must be of the form \"<role>-site<site number>\".
+        \"#{box.to_s}\" was passed." unless box_split.length > 1
+      return {:role=>box_split[0].to_s, :site=>box_split[1].to_i, :index=>index}
     end
 
     def node_name_from_definition(environment, role, site, index)


### PR DESCRIPTION
The expand_hashes function would previously silently fail when passed an argument of the wrong form. Passing, for example, "cedar" rather than the proper form "cedar-site1" would cause the site parameter to be set to zero by casting 'nil' to an integer. This led to some problems in diagnosing a related issue.

This fix will make the expand_hashes function throw an exception when its argument is not of the correct form.