### PR TITLE
[Reviewer: Seb] Update knife deployment describe

### DIFF
--- a/plugins/knife/knife-deployment-describe.rb
+++ b/plugins/knife/knife-deployment-describe.rb
@@ -84,7 +84,7 @@ module ClearwaterKnifePlugins
         "homer" => ["homer"],
         "ralf" => ["ralf", "chronos", "astaire"],
         "homestead" => ["homestead"],
-        "sprout" => ["sprout", "sprout-libs", "chronos", "memento", "astaire"],
+        "sprout" => ["sprout", "sprout-libs", "memento"],
         "dime" => ["ralf", "homestead"],
         "vellum" => ["chronos", "astaire", "rogers"]
       }

--- a/plugins/knife/knife-deployment-describe.rb
+++ b/plugins/knife/knife-deployment-describe.rb
@@ -55,7 +55,7 @@ module ClearwaterKnifePlugins
                 raw_dkpg_output = ssh.exec! "dpkg -l #{package_name}"
                 match_data = /#{package_name}\s+([0-9\.-]+)/.match raw_dkpg_output
                 if match_data.nil?
-                  puts "No package version found"
+                  puts "No package version found for #{package_name}"
                 else
                   version = match_data[1]
                   versions.each_with_index do |v, i|

--- a/plugins/knife/knife-deployment-describe.rb
+++ b/plugins/knife/knife-deployment-describe.rb
@@ -86,7 +86,7 @@ module ClearwaterKnifePlugins
         "homestead" => ["homestead"],
         "sprout" => ["sprout", "sprout-libs", "chronos", "memento", "astaire"],
         "dime" => ["ralf", "homestead"],
-        "vellum" => ["chronos", "astaire"]
+        "vellum" => ["chronos", "astaire", "rogers"]
       }
     end
 


### PR DESCRIPTION
Seb,

This fixes knife deployment describe:

- We now describe the version of rogers (as a result of https://github.com/Metaswitch/astaire/pull/93)
- Sprout no longer has Chronos and Astaire (this is a result of the split storage changes)
- I've improved a log line so that you get

```
Packages on rjw2-sprout-1:
sprout                         1.0-171019.160039
sprout-libs                    1.0-171019.160039
No package version found for memento
```

  instead of just `No package version found` for each package not found.