### PR TITLE
[Reviewer: SS5] Fixing broken chef recipe for shared_config

### DIFF
--- a/cookbooks/clearwater/recipes/shared_config.rb
+++ b/cookbooks/clearwater/recipes/shared_config.rb
@@ -16,8 +16,8 @@ end
 
 execute "download_shared_config" do
   user "ubuntu"
-  command "/usr/share/clearwater/clearwater-config-manager/scripts/cw-config download shared_config"
-  action :nothing
+  command "/usr/share/clearwater/clearwater-config-manager/scripts/cw-config download shared_config --autoconfirm"
+  action :run
 end
 
 domain = if node[:clearwater][:use_subdomain]
@@ -74,7 +74,7 @@ end
 
 # cw-config downloads files to ~/clearwater-config-manager/[USERNAME]. Users
 # modify the file and then upload it from there.
-template "/home/ubuntu/clearwater-config-manager/ubuntu/shared_config" do
+template "/home/ubuntu/clearwater-config-manager/root/shared_config" do
   mode "0644"
   source "shared_config.erb"
   variables domain: domain,
@@ -131,6 +131,6 @@ end
 
 execute "upload_shared_config" do
   user "ubuntu"
-  command "/usr/share/clearwater/clearwater-config-manager/scripts/cw-config upload shared_config"
+  command "/usr/share/clearwater/clearwater-config-manager/scripts/cw-config upload shared_config --autoconfirm"
   action :nothing
 end

--- a/cookbooks/clearwater/recipes/shared_config.rb
+++ b/cookbooks/clearwater/recipes/shared_config.rb
@@ -14,6 +14,12 @@ package "clearwater-management" do
   options "--force-yes"
 end
 
+execute "download_shared_config" do
+  user "clearwater"
+  command "/usr/share/clearwater/clearwater-config-manager/scripts/cw-config download shared_config"
+  action :nothing
+end
+
 domain = if node[:clearwater][:use_subdomain]
            node.chef_environment + "." + node[:clearwater][:root_domain]
          else
@@ -66,7 +72,9 @@ for i in 1..number_of_sites
   sprout_aliases.push("sprout-site#{i}." + domain)
 end
 
-template "/etc/clearwater/shared_config" do
+# cw-config downloads files to ~/clearwater-config-manager/[USERNAME]. Users
+# modify the file and then upload it from there.
+template "/home/clearwater/clearwater-config-manager/clearwater/shared_config" do
   mode "0644"
   source "shared_config.erb"
   variables domain: domain,
@@ -122,7 +130,7 @@ execute "poll_etcd" do
 end
 
 execute "upload_shared_config" do
-  user "root"
-  command "/usr/share/clearwater/clearwater-config-manager/scripts/upload_shared_config"
+  user "clearwater"
+  command "/usr/share/clearwater/clearwater-config-manager/scripts/cw-config upload shared_config"
   action :nothing
 end

--- a/cookbooks/clearwater/recipes/shared_config.rb
+++ b/cookbooks/clearwater/recipes/shared_config.rb
@@ -15,7 +15,7 @@ package "clearwater-management" do
 end
 
 execute "download_shared_config" do
-  user "clearwater"
+  user "ubuntu"
   command "/usr/share/clearwater/clearwater-config-manager/scripts/cw-config download shared_config"
   action :nothing
 end
@@ -74,7 +74,7 @@ end
 
 # cw-config downloads files to ~/clearwater-config-manager/[USERNAME]. Users
 # modify the file and then upload it from there.
-template "/home/clearwater/clearwater-config-manager/clearwater/shared_config" do
+template "/home/ubuntu/clearwater-config-manager/ubuntu/shared_config" do
   mode "0644"
   source "shared_config.erb"
   variables domain: domain,
@@ -130,7 +130,7 @@ execute "poll_etcd" do
 end
 
 execute "upload_shared_config" do
-  user "clearwater"
+  user "ubuntu"
   command "/usr/share/clearwater/clearwater-config-manager/scripts/cw-config upload shared_config"
   action :nothing
 end


### PR DESCRIPTION
This fixes up the chef recipe  for `shared_config` so that it uses the new `cw-config` script. I've tested this and it works provided we make a small fix to cw-config at the same time (covered by a separate pull request.