### PR TITLE
Unmonitor group for killing box

### DIFF
--- a/plugins/knife/boxes.rb
+++ b/plugins/knife/boxes.rb
@@ -332,8 +332,8 @@ def quiesce_box(box_name, env)
 
   Net::SSH.start(hostname, "ubuntu", ssh_options) do |ssh|
     ssh.exec! "sudo monit unmonitor -g etcd"
-    ssh.exec! "sudo monit unmonitor clearwater_config_manager"
-    ssh.exec! "sudo monit unmonitor clearwater_cluster_manager"
+    ssh.exec! "sudo monit unmonitor -g clearwater_config_manager"
+    ssh.exec! "sudo monit unmonitor -g clearwater_cluster_manager"
     ssh.exec! "sudo service clearwater-etcd decommission"
     case node.run_list.first.name
     when "sprout"


### PR DESCRIPTION
Fixes a bug that chef wasn't able to quiesce box succeessfullly. 

Live tested by:
1. make change to  chef submodule in chef-private
2. create deployment with three Vellums
3. resize to two Vellums and see the operation succeeded