### PR TITLE
Pause to avoid config change race

### DIFF
--- a/cookbooks/clearwater/recipes/shared_config.rb
+++ b/cookbooks/clearwater/recipes/shared_config.rb
@@ -27,6 +27,7 @@ ruby_block "wait_for_etcd" do
     end
   end
   notifies :run, "execute[poll_etcd]", :immediately
+  sleep 60
   notifies :run, "execute[download_shared_config]", :immediately
 end
 


### PR DESCRIPTION
This is a temporary workaround for problems we've seen in how this interacts with shared config infrastructure changes. Should be removed once it's sorted.