### PR TITLE
Allow Chef to setup new SAS configuration

### DIFF
--- a/cookbooks/clearwater/recipes/shared_config.rb
+++ b/cookbooks/clearwater/recipes/shared_config.rb
@@ -133,3 +133,24 @@ execute "upload_shared_config" do
   command "/usr/share/clearwater/clearwater-config-manager/scripts/cw-config upload shared_config --autoconfirm"
   action :nothing
 end
+
+execute "download_sas_config" do
+  user "ubuntu"
+  command "/usr/share/clearwater/clearwater-config-manager/scripts/cw-config download sas.json --autoconfirm"
+  action :run
+end
+
+sas_ip = IPSocket.getaddress(node[:clearwater][:sas_server])
+
+template "/home/ubuntu/clearwater-config-manager/root/sas.json" do
+  mode "0644"
+  source "sas.json.erb"
+  variables sas_ip: sas_ip
+  notifies :run, "execute[upload_sas_config]", :immediately
+end
+
+execute "upload_sas_config" do
+  user "ubuntu"
+  command "/usr/share/clearwater/clearwater-config-manager/scripts/cw-config upload sas.json --autoconfirm"
+  action :nothing
+end

--- a/cookbooks/clearwater/templates/default/sas.json.erb
+++ b/cookbooks/clearwater/templates/default/sas.json.erb
@@ -1,0 +1,5 @@
+{
+  "sas_servers" : [
+    {"ip" : "@sas_ip"}
+  ]
+}

--- a/cookbooks/clearwater/templates/default/sas.json.erb
+++ b/cookbooks/clearwater/templates/default/sas.json.erb
@@ -1,5 +1,5 @@
 {
   "sas_servers" : [
-    {"ip" : "@sas_ip"}
+    {"ip" : "<%= @sas_ip %>"}
   ]
 }

--- a/cookbooks/clearwater/templates/default/shared_config.erb
+++ b/cookbooks/clearwater/templates/default/shared_config.erb
@@ -14,7 +14,8 @@ sprout_registration_store=<%= @sprout_registration_store %>
 cassandra_hostname=<%= @cassandra_hostname %>
 chronos_hostname=<%= @chronos_hostname %>
 ralf_session_store=<%= @ralf_session_store %>
-<% if not @memento_auth_store.nil? %>memento_auth_store=<%= @memento_auth_store %><% end %>enum_server=<%= @node[:clearwater][:enum_server] or "" %>
+<% if not @memento_auth_store.nil? %>memento_auth_store=<%= @memento_auth_store %><% end %>
+enum_server=<%= @node[:clearwater][:enum_server] or "" %>
 alias_list=<%= @alias_list %>
 scscf_uri=<%= @scscf_uri %>
 upstream_port=<%= @upstream_port %>

--- a/cookbooks/clearwater/templates/default/shared_config.erb
+++ b/cookbooks/clearwater/templates/default/shared_config.erb
@@ -14,9 +14,7 @@ sprout_registration_store=<%= @sprout_registration_store %>
 cassandra_hostname=<%= @cassandra_hostname %>
 chronos_hostname=<%= @chronos_hostname %>
 ralf_session_store=<%= @ralf_session_store %>
-<% if not @memento_auth_store.nil? %>memento_auth_store=<%= @memento_auth_store %><% end %>
-sas_server=<%= @node[:clearwater][:sas_server] or "0.0.0.0" %>
-enum_server=<%= @node[:clearwater][:enum_server] or "" %>
+<% if not @memento_auth_store.nil? %>memento_auth_store=<%= @memento_auth_store %><% end %>enum_server=<%= @node[:clearwater][:enum_server] or "" %>
 alias_list=<%= @alias_list %>
 scscf_uri=<%= @scscf_uri %>
 upstream_port=<%= @upstream_port %>


### PR DESCRIPTION
Make Chef configure SAS using the new sas.json config file rather than the option in shared_config.