### PR TITLE
sleep to bypass request limit

### DIFF
--- a/plugins/knife/security-groups.rb
+++ b/plugins/knife/security-groups.rb
@@ -54,7 +54,7 @@ module Clearwater
     def add_security_group_rule(group, rule)
       Chef::Log.info "Adding rule #{rule} to #{group.name}"
       group.authorize_port_range(PortRangeObject.new(rule), rule)
-	  sleep 1
+      sleep 1
     end
 
     # Add a list of rules to a group.
@@ -72,7 +72,7 @@ module Clearwater
     def remove_security_group_rule(group, rule)
       Chef::Log.info "Revoking rule #{rule} from #{group.name}"
       group.revoke_port_range(PortRangeObject.new(rule), rule)
-	  sleep 1
+      sleep 1
     end
 
     # Remove a list of rules from a group.

--- a/plugins/knife/security-groups.rb
+++ b/plugins/knife/security-groups.rb
@@ -54,6 +54,7 @@ module Clearwater
     def add_security_group_rule(group, rule)
       Chef::Log.info "Adding rule #{rule} to #{group.name}"
       group.authorize_port_range(PortRangeObject.new(rule), rule)
+	  sleep 1
     end
 
     # Add a list of rules to a group.
@@ -71,6 +72,7 @@ module Clearwater
     def remove_security_group_rule(group, rule)
       Chef::Log.info "Revoking rule #{rule} from #{group.name}"
       group.revoke_port_range(PortRangeObject.new(rule), rule)
+	  sleep 1
     end
 
     # Remove a list of rules from a group.


### PR DESCRIPTION
When creating security groups, you will encounter a "RequestLimitExceeded" error when assigning them to instances too fast. This limit is fundamental to AWS hence cannot be bypassed without limiting the speed in-solution. Hence, I have added a 1 second sleep to prevent this error from occurring. 